### PR TITLE
Issue74 - Clarified immutable/mutable in glossary

### DIFF
--- a/_sources/CollectionData/glossary.rst
+++ b/_sources/CollectionData/glossary.rst
@@ -17,10 +17,10 @@ Glossary
     hash table
         a collection consisting of key-value pairs with an associated hash function that maps the key to the associated value.
 
-    immutable
+    const (immutable)
         unable to be modified.
 
-    mutability
+    non-const (mutable)
         the ability of an object to be modified.
 
     set


### PR DESCRIPTION
I added const / non-const text to the glossary. I did leave Immutable and Mutable in parentheses because they are still concepts in C++, especially in regards to memory management.