### PR TITLE
Fix typo in AtomicData

### DIFF
--- a/_sources/AtomicData/AtomicData.rst
+++ b/_sources/AtomicData/AtomicData.rst
@@ -700,7 +700,7 @@ On the first iteration of the loop, it is assigned the value of
             int *ptrx = &x;
 
             while (ptrx) {
-                cout << "Pointer ptrx points to " << &ptrx << endl;
+                cout << "Pointer ptrx points to " << ptrx << endl;
                 ptrx = nullptr;
             }
 


### PR DESCRIPTION
Fix typo in line 703 of _source/AtomicData/AtomicData.rst
More detail is discussed in issue #106.