### PR TITLE
Remove checkpoints across chapter 2 (cpp4python-v2)

### DIFF
--- a/pretext/AtomicData/BooleanData.ptx
+++ b/pretext/AtomicData/BooleanData.ptx
@@ -14,7 +14,7 @@
             , and <q>not</q> is given by <c>!</c>.
             Note that the internally stored values representing <c>true</c> and <c>false</c>
             are actually <c>1</c> and <c>0</c> respectively. Hence, we see this in output as well.</p>
-        <exercise ><TabNode tabname="C++" tabnode_options="{'subchapter': 'BooleanData', 'chapter': 'AtomicData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
+        <TabNode tabname="C++" tabnode_options="{'subchapter': 'BooleanData', 'chapter': 'AtomicData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
 
     <program xml:id="logical_1cpp" interactive="activecode" language="cpp">
         <input>
@@ -44,7 +44,7 @@ def main():
 main()
         </input>
     </program>
-            </TabNode></exercise>
+            </TabNode>
         <p>Boolean data objects are also used as results for comparison operators
             such as equality (==) and greater than (<math>&gt;</math>). In addition,
             relational operators and logical operators can be combined together to
@@ -173,7 +173,7 @@ main()
                 
             
         </tabular></table>
-        <exercise ><TabNode tabname="C++" tabnode_options="{'subchapter': 'BooleanData', 'chapter': 'AtomicData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
+        <TabNode tabname="C++" tabnode_options="{'subchapter': 'BooleanData', 'chapter': 'AtomicData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
 
     <program xml:id="locicalcpp" interactive="activecode" language="cpp">
         <input>
@@ -205,7 +205,7 @@ def main():
 main()
         </input>
     </program>
-            </TabNode></exercise>
+            </TabNode>
         <p>When a C++ variable is declared, space in memory is set aside to hold
             this type of value.
             A C++ variable can optionally be initialized in the declaration by
@@ -252,11 +252,12 @@ int main(){
             Pitfall: C++ will often simply try to do the assignment you
             requested without
             complaining. Note what happened in the code above in the final output.</p>
-
+            <reading-questions xml:id="rqs-bool-data">
+                <title>Reading Question</title>
     <exercise label="mc_bool">
         <statement>
 
-        <p>Q-6: Why did theBool output a value of 1 after being set to 4?</p>
+        <p>Why did theBool output a value of 1 after being set to 4?</p>
 
         </statement>
 <choices>
@@ -299,5 +300,6 @@ int main(){
 </choices>
 
     </exercise>
+</reading-questions>
     </section>
 

--- a/pretext/AtomicData/CharacterData.ptx
+++ b/pretext/AtomicData/CharacterData.ptx
@@ -4,7 +4,7 @@
             In C++ single quotes are used for the character (<c>char</c>) data type,
             and double quotes are used for the string data type.</p>
         <p>Consider the following code.</p>
-        <exercise ><TabNode tabname="Python" tabnode_options="{'subchapter': 'AtomicData', 'chapter': 'AtomicData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'Python'}">
+       <TabNode tabname="Python" tabnode_options="{'subchapter': 'AtomicData', 'chapter': 'AtomicData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'Python'}">
 
     <program xml:id="charpy" interactive="activecode" language="python">
         <input>
@@ -44,13 +44,14 @@ int main(){
 }
         </input>
     </program>
-            </TabNode></exercise>
+            </TabNode>
         <p>Try the following question.</p>
-
+<reading-questions xml:id="rqs-char-data">
+    <title>Reading Question</title>
     <exercise label="mc_cpp_strings">
         <statement>
 
-        <p>Q-13: If I want to create a string in C++, what set of symbols may be used?</p>
+        <p>If I want to create a string in C++, what set of symbols may be used?</p>
 
         </statement>
 <choices>
@@ -102,4 +103,5 @@ int main(){
 </choices>
 
     </exercise>
+</reading-questions>
     </section>

--- a/pretext/AtomicData/NumericData.ptx
+++ b/pretext/AtomicData/NumericData.ptx
@@ -15,7 +15,7 @@
         <p>Exponentiation in C++ is done using <c>pow()</c> from the <c>cmath</c> library
             and the remainder (modulo) operator is done with <c>%</c>.</p>
         <p>Run the following code to see that you understand each result.</p>
-        <exercise ><TabNode tabname="C++" tabnode_options="{'subchapter': 'NumericData', 'chapter': 'AtomicData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
+        <TabNode tabname="C++" tabnode_options="{'subchapter': 'NumericData', 'chapter': 'AtomicData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
 
     <program xml:id="intro_1cpp" interactive="activecode" language="cpp">
         <input>
@@ -64,16 +64,17 @@ def main():
 main()
         </input>
     </program>
-            </TabNode></exercise>
+            </TabNode>
         <p>When declaring numeric variables in C++,
             modifiers like <c>short</c>, <c>long</c>, and <c>unsigned</c>
             can optionally be used to help
             to ensure space is used as efficiently as possible.</p>
-
+            <reading-questions xml:id="rqs-numeric-data">
+                <title>Reading Questions</title>
     <exercise label="mc_integer_div">
         <statement>
 
-        <p>Q-3: what is the result of dividing <c>3/2</c> in C++?</p>
+        <p>what is the result of dividing <c>3/2</c> in C++?</p>
 
         </statement>
 <choices>
@@ -129,7 +130,7 @@ main()
     <exercise label="mc_exponentiation">
         <statement>
 
-        <p>Q-4: How do I raise 4 to 5th power in C++?</p>
+        <p>How do I raise 4 to 5th power in C++?</p>
 
         </statement>
 <choices>
@@ -172,5 +173,6 @@ main()
 </choices>
 
     </exercise>
+            </reading-questions>
     </section>
 

--- a/pretext/AtomicData/Pointers.ptx
+++ b/pretext/AtomicData/Pointers.ptx
@@ -37,7 +37,7 @@ int varN = 100;</pre>
             way to reference the address.</p>
         <p>In Python we use <c>id</c> to reference the address,
             while in C++ we use the <em>address-of operator</em>, <c>&amp;</c>.</p>
-        <exercise ><TabNode tabname="C++" tabnode_options="{'subchapter': 'Pointers', 'chapter': 'AtomicData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
+      <TabNode tabname="C++" tabnode_options="{'subchapter': 'Pointers', 'chapter': 'AtomicData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
 
     <program xml:id="address_cpp" interactive="activecode" language="cpp">
         <input>
@@ -69,7 +69,7 @@ def main():
 main()
         </input>
     </program>
-            </TabNode></exercise>
+            </TabNode>
         <p>In both Python and C++, variables are stored in memory locations which are dependent
             upon the run itself. If you repeatedly run the above code in either C++ or Python, you may
             see the location change.</p>
@@ -152,61 +152,7 @@ int main( ) {
     </program>
             </blockquote>
 
-    <exercise label="mc_pntrhlp">
-        <statement>
-
-            <p>Q-4: If the lines (varN = 50;) and  (cout &lt;&lt; *ptrN &lt;&lt; endl;) were inserted into line 7-8, what would it cout?</p>
-
-        </statement>
-<choices>
-
-            <choice>
-                <statement>
-                    <p>varPntr: 9</p>
-                </statement>
-                <feedback>
-                    <p>Not quite, the variable varN no longer equals 100 past line 7!</p>
-                </feedback>
-            </choice>
-
-            <choice correct="yes">
-                <statement>
-                    <p>varPntr: 50</p>
-                </statement>
-                <feedback>
-                    <p>Right!</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>varPntr: 150</p>
-                </statement>
-                <feedback>
-                    <p>No, the values do not add together!</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>0x7ffeb9ce053c</p>
-                </statement>
-                <feedback>
-                    <p>We are dereferencing the pointer, so you would not get the address of varN. Try again!</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>none of the above</p>
-                </statement>
-                <feedback>
-                    <p>One of the above is indeed correct.</p>
-                </feedback>
-            </choice>
-</choices>
-
-    </exercise>
+    
             <p>Compiling and running the above code will have the program output the
                 value in varN,
                 what is in ptrN (the memory address of varN),
@@ -295,6 +241,67 @@ int main( ) {
             <p>Helpful Tip: The null pointer becomes very useful when you must test
                 the state of a pointer, such as whether the assignment to an address
                 is valid or not.</p>
+
+
+                <reading-questions xml:id="rqs-pointers">
+                    <title>Reading Question</title>
+                    
+                    <exercise label="mc_pntrhlp">
+                        <statement>
+                
+                            <p>If the lines (varN = 50;) and  (cout &lt;&lt; *ptrN &lt;&lt; endl;) were inserted into line 7-8, what would it cout?</p>
+                
+                        </statement>
+                <choices>
+                
+                            <choice>
+                                <statement>
+                                    <p>varPntr: 9</p>
+                                </statement>
+                                <feedback>
+                                    <p>Not quite, the variable varN no longer equals 100 past line 7!</p>
+                                </feedback>
+                            </choice>
+                
+                            <choice correct="yes">
+                                <statement>
+                                    <p>varPntr: 50</p>
+                                </statement>
+                                <feedback>
+                                    <p>Right!</p>
+                                </feedback>
+                            </choice>
+                
+                            <choice>
+                                <statement>
+                                    <p>varPntr: 150</p>
+                                </statement>
+                                <feedback>
+                                    <p>No, the values do not add together!</p>
+                                </feedback>
+                            </choice>
+                
+                            <choice>
+                                <statement>
+                                    <p>0x7ffeb9ce053c</p>
+                                </statement>
+                                <feedback>
+                                    <p>We are dereferencing the pointer, so you would not get the address of varN. Try again!</p>
+                                </feedback>
+                            </choice>
+                
+                            <choice>
+                                <statement>
+                                    <p>none of the above</p>
+                                </statement>
+                                <feedback>
+                                    <p>One of the above is indeed correct.</p>
+                                </feedback>
+                            </choice>
+                </choices>
+                
+                    </exercise>
+                </reading-questions> 
         </subsection>
     </section>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
I removed checkpoints across chapter two, and I also labeled the multiple choice problems as reading questions at the end of the section where they belong to know they show up as reading questions instead of checkpoints. also, many active code was showing as a checkpoint. I removed the checkpoint from the active code, too.

## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
fix #121
## How Has This Been Tested?
1. Make changes locally.
2. Verify the changes.
![image](https://github.com/pearcej/cpp4python/assets/117699634/b7be0b73-3016-420e-a7ea-787427994b50)
![image](https://github.com/pearcej/cpp4python/assets/117699634/16569732-e4ad-4948-a51f-86cc3dc4e0f7)

<!--- Please describe in detail how you tested your changes. -->
