### PR TITLE
Remove checkpoints across chapter 3 (cpp4python-v2)

### DIFF
--- a/pretext/Control_Structures/conditionals.ptx
+++ b/pretext/Control_Structures/conditionals.ptx
@@ -141,38 +141,10 @@ main()
  }
         </input>
     </program>
-            <subsubsection xml:id="control_-structures_check-yourself">
-                <title>Check Yourself</title>
+            
 
-    <exercise label="mc_cpp_elsecond">
-        <statement>
+    
 
-                <p>Q-4: T/F: It is necessary to have an else statement after an if statement. (Hint: Test it out in the code above.)</p>
-
-        </statement>
-<choices>
-
-            <choice>
-                <statement>
-                    <p>True</p>
-                </statement>
-                <feedback>
-                    <p>Not quite, try modifying the code above to test it out.</p>
-                </feedback>
-            </choice>
-
-            <choice correct="yes">
-                <statement>
-                    <p>False</p>
-                </statement>
-                <feedback>
-                    <p>Good job!</p>
-                </feedback>
-            </choice>
-</choices>
-
-    </exercise>
-            </subsubsection>
         </subsection>
         <subsection xml:id="control_-structures_switch">
             <title>switch</title>
@@ -231,159 +203,186 @@ main()
                 grade was 95 and the <c>break</c> was omitted from the <c>case 9:</c>
                 alternative then the program would print out both (A and B.)
                 So, you might want to just avoid it and use if&#8230;</p>
-            <subsubsection xml:id="control_-structures_id1">
-                <title>Check Yourself</title>
-
-    <exercise label="mc_cpp_ifcond">
-        <statement>
-
-                <p>Q-6: When indicating the condition for a C++ if statement, what symbols are used?</p>
-
-        </statement>
-<choices>
-
-            <choice>
-                <statement>
-                    <p>{ }</p>
-                </statement>
-                <feedback>
-                    <p>No. Try again.</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>[ ]</p>
-                </statement>
-                <feedback>
-                    <p>No. Try again.</p>
-                </feedback>
-            </choice>
-
-            <choice correct="yes">
-                <statement>
-                    <p>( )</p>
-                </statement>
-                <feedback>
-                    <p>Right!</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>Any set of matching braces may be used.</p>
-                </statement>
-                <feedback>
-                    <p>No. Try again.</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>none of the above</p>
-                </statement>
-                <feedback>
-                    <p>One of the above is indeed correct.</p>
-                </feedback>
-            </choice>
-</choices>
-
-    </exercise>
-
-    <exercise label="mc_cpp_switch">
-        <statement>
-
-                <p>Q-7: When using a switch, what prevents all the cases from passing as correct?</p>
-
-        </statement>
-<choices>
-
-            <choice>
-                <statement>
-                    <p>Ending statements with ;</p>
-                </statement>
-                <feedback>
-                    <p>No. This is always needed.</p>
-                </feedback>
-            </choice>
-
-            <choice correct="yes">
-                <statement>
-                    <p>Using a break statement</p>
-                </statement>
-                <feedback>
-                    <p>Good job!</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>Enclosing each cases with { }</p>
-                </statement>
-                <feedback>
-                    <p>No. Try again.</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>Setting a default case</p>
-                </statement>
-                <feedback>
-                    <p>No. This is a good idea, but it will not help.</p>
-                </feedback>
-            </choice>
-</choices>
-
-    </exercise>
-
-    <exercise label="mc_cpp_and">
-        <statement>
-
-                <p>Q-8: What symbol is used to indicate the <q>and</q> in C++ such as in a compound condition?</p>
-
-        </statement>
-<choices>
-
-            <choice>
-                <statement>
-                    <p>||</p>
-                </statement>
-                <feedback>
-                    <p>No, this means "or".</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>and</p>
-                </statement>
-                <feedback>
-                    <p>No, this is Python.</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>!</p>
-                </statement>
-                <feedback>
-                    <p>No, this means "not"</p>
-                </feedback>
-            </choice>
-
-            <choice correct="yes">
-                <statement>
-                    <p>&amp;&amp;</p>
-                </statement>
-                <feedback>
-                    <p>Very good!</p>
-                </feedback>
-            </choice>
-</choices>
-
-    </exercise>
-            </subsubsection>
+            <reading-questions xml:id="rqs-conditionals">
+                <title>Reading Questions</title>
+                <exercise label="mc_cpp_elsecond">
+                    <statement>
+            
+                            <p>T/F: It is necessary to have an else statement after an if statement. (Hint: Test it out in the code above.)</p>
+            
+                    </statement>
+            <choices>
+            
+                        <choice>
+                            <statement>
+                                <p>True</p>
+                            </statement>
+                            <feedback>
+                                <p>Not quite, try modifying the code above to test it out.</p>
+                            </feedback>
+                        </choice>
+            
+                        <choice correct="yes">
+                            <statement>
+                                <p>False</p>
+                            </statement>
+                            <feedback>
+                                <p>Good job!</p>
+                            </feedback>
+                        </choice>
+            </choices>
+            
+                </exercise>
+                <exercise label="mc_cpp_ifcond">
+                    <statement>
+            
+                            <p>When indicating the condition for a C++ if statement, what symbols are used?</p>
+            
+                    </statement>
+            <choices>
+            
+                        <choice>
+                            <statement>
+                                <p>{ }</p>
+                            </statement>
+                            <feedback>
+                                <p>No. Try again.</p>
+                            </feedback>
+                        </choice>
+            
+                        <choice>
+                            <statement>
+                                <p>[ ]</p>
+                            </statement>
+                            <feedback>
+                                <p>No. Try again.</p>
+                            </feedback>
+                        </choice>
+            
+                        <choice correct="yes">
+                            <statement>
+                                <p>( )</p>
+                            </statement>
+                            <feedback>
+                                <p>Right!</p>
+                            </feedback>
+                        </choice>
+            
+                        <choice>
+                            <statement>
+                                <p>Any set of matching braces may be used.</p>
+                            </statement>
+                            <feedback>
+                                <p>No. Try again.</p>
+                            </feedback>
+                        </choice>
+            
+                        <choice>
+                            <statement>
+                                <p>none of the above</p>
+                            </statement>
+                            <feedback>
+                                <p>One of the above is indeed correct.</p>
+                            </feedback>
+                        </choice>
+            </choices>
+            
+                </exercise>
+                <exercise label="mc_cpp_switch">
+                    <statement>
+            
+                            <p>When using a switch, what prevents all the cases from passing as correct?</p>
+            
+                    </statement>
+            <choices>
+            
+                        <choice>
+                            <statement>
+                                <p>Ending statements with ;</p>
+                            </statement>
+                            <feedback>
+                                <p>No. This is always needed.</p>
+                            </feedback>
+                        </choice>
+            
+                        <choice correct="yes">
+                            <statement>
+                                <p>Using a break statement</p>
+                            </statement>
+                            <feedback>
+                                <p>Good job!</p>
+                            </feedback>
+                        </choice>
+            
+                        <choice>
+                            <statement>
+                                <p>Enclosing each cases with { }</p>
+                            </statement>
+                            <feedback>
+                                <p>No. Try again.</p>
+                            </feedback>
+                        </choice>
+            
+                        <choice>
+                            <statement>
+                                <p>Setting a default case</p>
+                            </statement>
+                            <feedback>
+                                <p>No. This is a good idea, but it will not help.</p>
+                            </feedback>
+                        </choice>
+            </choices>
+            
+                </exercise>
+                <exercise label="mc_cpp_and">
+                    <statement>
+            
+                            <p>What symbol is used to indicate the <q>and</q> in C++ such as in a compound condition?</p>
+            
+                    </statement>
+            <choices>
+            
+                        <choice>
+                            <statement>
+                                <p>||</p>
+                            </statement>
+                            <feedback>
+                                <p>No, this means "or".</p>
+                            </feedback>
+                        </choice>
+            
+                        <choice>
+                            <statement>
+                                <p>and</p>
+                            </statement>
+                            <feedback>
+                                <p>No, this is Python.</p>
+                            </feedback>
+                        </choice>
+            
+                        <choice>
+                            <statement>
+                                <p>!</p>
+                            </statement>
+                            <feedback>
+                                <p>No, this means "not"</p>
+                            </feedback>
+                        </choice>
+            
+                        <choice correct="yes">
+                            <statement>
+                                <p>&amp;&amp;</p>
+                            </statement>
+                            <feedback>
+                                <p>Very good!</p>
+                            </feedback>
+                        </choice>
+            </choices>
+            
+                </exercise>
+            
+                
+            </reading-questions>
         </subsection>
     </section>
 

--- a/pretext/Control_Structures/for_loop.ptx
+++ b/pretext/Control_Structures/for_loop.ptx
@@ -53,11 +53,12 @@ int main() {
 
     return 0;
 }</pre>
-
+<reading-questions xml:id="rqs-for_loop">
+    <title>Reading Question</title>
     <exercise label="mc_forloop">
         <statement>
 
-            <p>Q-3: Using the code above please select the answer that should appear?</p>
+            <p>Using the code above please select the answer that should appear?</p>
 
         </statement>
 <choices>
@@ -109,6 +110,7 @@ int main() {
 </choices>
 
     </exercise>
+</reading-questions>
         </subsection>
     </section>
 

--- a/pretext/Control_Structures/glossary.ptx
+++ b/pretext/Control_Structures/glossary.ptx
@@ -34,12 +34,12 @@
                 </gi>
             
         </glossary>
-        <subsection xml:id="control_-structures_matching">
-            <title>Matching</title>
 
+<reading-questions xml:id="rqs-glossary3">
+    <title>Reading Question</title>
 <exercise label="matching_ControlStructures">
     <statement><p>Drag each glossary term to its' corresponding definition.</p></statement>
     <feedback><p>Feedback shows incorrect matches.</p></feedback>
-<matches><match order="1"><premise>break</premise><response>Terminates the current block of code and resumes the program outside of it.</response></match><match order="2"><premise>case</premise><response>Condition in a switch statement for a variable to be tested against.</response></match><match order="3"><premise>conditional</premise><response>Statement that tests whether a condition is true or false .</response></match><match order="4"><premise>loop</premise><response>Series of instructions repeated infinitely or until a condition is met.</response></match><match order="5"><premise>switch</premise><response>Statement that tests a variable against possible conditions for it.</response></match></matches></exercise>        </subsection>
+<matches><match order="1"><premise>break</premise><response>Terminates the current block of code and resumes the program outside of it.</response></match><match order="2"><premise>case</premise><response>Condition in a switch statement for a variable to be tested against.</response></match><match order="3"><premise>conditional</premise><response>Statement that tests whether a condition is true or false .</response></match><match order="4"><premise>loop</premise><response>Series of instructions repeated infinitely or until a condition is met.</response></match><match order="5"><premise>switch</premise><response>Statement that tests a variable against possible conditions for it.</response></match></matches></exercise> </reading-questions>    
     </section>
 

--- a/pretext/Control_Structures/while_loop.ptx
+++ b/pretext/Control_Structures/while_loop.ptx
@@ -60,11 +60,15 @@ int main(){
         cout &lt;&lt; "Hello, world!" &lt;&lt; endl;
     }
 };</pre>
+<reading-questions xml:id="rqs-while_loop">
+    <title>Reading Question</title>
+    
+    
 
     <exercise label="mc_whileloop">
         <statement>
 
-        <p>Q-1: Using the code above please select the answer that should appear.</p>
+        <p>Using the code above please select the answer that should appear.</p>
 
         </statement>
 <choices>
@@ -107,5 +111,6 @@ int main(){
 </choices>
 
     </exercise>
+</reading-questions>
     </section>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
I removed checkpoints across chapter three, and I also labeled the multiple choice problems as reading questions at the end of the section where they belong to know they show up as reading questions instead of checkpoints. also, many active code was showing as a checkpoint. I removed the checkpoint from the active code, too.

## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
fix #124 
## How Has This Been Tested?
1. Make changes locally.
2. Verify the changes.
![image](https://github.com/pearcej/cpp4python/assets/117699634/cfff5607-0394-428b-b820-a62168afe0bf)
![image](https://github.com/pearcej/cpp4python/assets/117699634/5c106b2d-5979-44fa-a9d2-16929c98d038)


<!--- Please describe in detail how you tested your changes. -->
