### PR TITLE
Remove checkpoints across chapter 4 (cpp4python-v2)

### DIFF
--- a/pretext/Functions/DefiningFunctions.ptx
+++ b/pretext/Functions/DefiningFunctions.ptx
@@ -133,11 +133,12 @@ int main() {
 }
         </input>
     </program>
-
+    <reading-questions xml:id="rqs-defining-functions">
+        <title>Reading Question</title>
     <exercise label="dog_walker">
         <statement>
 
-        <p>Q-5: What is the correct return type of the function above <term>int main()</term>?</p>
+        <p>What is the correct return type of the function above <term>int main()</term>?</p>
 
         </statement>
 <choices>
@@ -180,5 +181,6 @@ int main() {
 </choices>
 
     </exercise>
+</reading-questions>
     </section>
 

--- a/pretext/Functions/FunctionOverloading.ptx
+++ b/pretext/Functions/FunctionOverloading.ptx
@@ -11,7 +11,7 @@
             Python requires a different technique.</p>
         <p>See the following example where an optional parameter is used to accomplish the
             same task.</p>
-        <exercise ><TabNode tabname="C++" tabnode_options="{'subchapter': 'FunctionOverloading', 'chapter': 'Functions', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
+    <TabNode tabname="C++" tabnode_options="{'subchapter': 'FunctionOverloading', 'chapter': 'Functions', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
 
     <program xml:id="foverload_cpp" interactive="activecode" language="cpp">
         <input>
@@ -59,12 +59,15 @@ def main():
 main()
         </input>
     </program>
-            </TabNode></exercise>
-
+            </TabNode>
+<reading-questions xml:id="rqs-func-overloading">
+    <title>Reading Questions</title>
+    
+    
     <exercise label="foverloading">
         <statement>
 
-        <p>Q-3: What are benefits of function overloading?</p>
+        <p>What are benefits of function overloading?</p>
 
         </statement>
 <choices>
@@ -107,34 +110,38 @@ main()
 </choices>
 
     </exercise>
-        <note>
-            <title>Self Check</title>
-            <p>Here's a self check that really covers everything so far.  You may have
-                heard of the infinite monkey theorem?  The theorem states that a monkey
-                hitting keys at random on a typewriter keyboard for an infinite amount of
-                time will almost surely type a given text, such as the complete works of
-                William Shakespeare.  Well, suppose we replace a monkey with a C++ function.
-                How long do you think it would take for a C++ function to generate just one
-                sentence of Shakespeare?  The sentence we'll shoot for is:  <q>methinks it is
-                like a weasel</q></p>
-            <p>You're not going to want to run this one in the browser, so fire up your favorite
-                C++ IDE.  The way we'll simulate this is to write a function that generates a string
-                that is 28 characters long by choosing random letters from the 26 letters in the
-                alphabet plus the space.  We'll write another function that will score each
-                generated string by comparing the randomly generated string to the goal.
-                Hint: You will need to import the &lt;random&gt; library for this.</p>
-            <p>A third function will repeatedly call generate and score, then if 100% of
-                the letters are correct we are done.  If the letters are not correct then
-                we will generate a whole new string. To make it easier to follow your program's
-                progress this third function should print out the best string generated so far
-                and its score every 1000 tries.</p>
-        </note>
-        <note>
-            <title>Self Check Challenge</title>
-            <p>See if you can improve upon the program in the self check by keeping letters
-                that are correct and only modifying one character in the best string so far.
-                This is a type of algorithm in the class of &#8216;hill climbing' algorithms, that
-                is we only keep the result if it is better than the previous one.</p>
-        </note>
-    </section>
+    <exercise>
+            
+        <title>Self Check</title>
+        <p>Here's a self check that really covers everything so far.  You may have
+            heard of the infinite monkey theorem?  The theorem states that a monkey
+            hitting keys at random on a typewriter keyboard for an infinite amount of
+            time will almost surely type a given text, such as the complete works of
+            William Shakespeare.  Well, suppose we replace a monkey with a C++ function.
+            How long do you think it would take for a C++ function to generate just one
+            sentence of Shakespeare?  The sentence we'll shoot for is:  <q>methinks it is
+            like a weasel</q></p>
+        <p>You're not going to want to run this one in the browser, so fire up your favorite
+            C++ IDE.  The way we'll simulate this is to write a function that generates a string
+            that is 28 characters long by choosing random letters from the 26 letters in the
+            alphabet plus the space.  We'll write another function that will score each
+            generated string by comparing the randomly generated string to the goal.
+            Hint: You will need to import the &lt;random&gt; library for this.</p>
+        <p>A third function will repeatedly call generate and score, then if 100% of
+            the letters are correct we are done.  If the letters are not correct then
+            we will generate a whole new string. To make it easier to follow your program's
+            progress this third function should print out the best string generated so far
+            and its score every 1000 tries.</p>
+        </exercise>
+        <exercise>
+        
+    
+        <title>Self Check Challenge</title>
+        <p>See if you can improve upon the program in the self check by keeping letters
+            that are correct and only modifying one character in the best string so far.
+            This is a type of algorithm in the class of &#8216;hill climbing' algorithms, that
+            is we only keep the result if it is better than the previous one.</p>
+        </exercise>    
+</reading-questions>
+</section>
 

--- a/pretext/Functions/ParameterPassingByValue.ptx
+++ b/pretext/Functions/ParameterPassingByValue.ptx
@@ -123,11 +123,15 @@ int main(){
 }
         </input>
     </program>
+<reading-questions xml:id="rqs-parameter-passing-by-value">
+    <title>Reading Questions</title>
+    
+    
 
     <exercise label="question1_1">
         <statement>
 
-        <p>Q-3: What is the difference between <term>func1</term> and <term>func2</term>? Check all that apply.</p>
+        <p>What is the difference between <term>func1</term> and <term>func2</term>? Check all that apply.</p>
 
         </statement>
 <choices>
@@ -174,7 +178,7 @@ int main(){
     <exercise label="question1_2">
         <statement>
 
-        <p>Q-4: Why does adding the <q>&amp;</q> to parameters in the <term>func</term> function cause the output to be a different result?</p>
+        <p>Why does adding the <q>&amp;</q> to parameters in the <term>func</term> function cause the output to be a different result?</p>
 
         </statement>
 <choices>
@@ -217,6 +221,7 @@ int main(){
 </choices>
 
     </exercise>
+</reading-questions>
         <transition/>
     </section>
 

--- a/pretext/Functions/glossary.ptx
+++ b/pretext/Functions/glossary.ptx
@@ -46,12 +46,14 @@
                 </gi>
             
         </glossary>
-        <subsection xml:id="functions_matching">
-            <title>Matching</title>
-
+     <reading-questions xml:id="rqs-">
+        <title>Reading Question</title>
+        
+        
+    
 <exercise label="matching_Functions">
     <statement><p>Drag each glossary term to its' corresponding definition.</p></statement>
     <feedback><p>Feedback shows incorrect matches.</p></feedback>
-<matches><match order="1"><premise>argument</premise><response>Data passed to parameter.</response></match><match order="2"><premise>const</premise><response>indicates a variable or value is unchanging.</response></match><match order="3"><premise>function </premise><response> Section of code that performs a procedure and usually is named meaningfully.</response></match><match order="4"><premise>overloading</premise><response>Specifying more than one definition for the same function name.</response></match><match order="5"><premise>parameter</premise><response>Variable in a function or method definition that accepts data passed from an argument.</response></match><match order="6"><premise>reference</premise><response>Value that indicates an address in a computer's memory.</response></match><match order="7"><premise>void</premise><response>indicates a function has no return value.</response></match></matches></exercise>        </subsection>
+<matches><match order="1"><premise>argument</premise><response>Data passed to parameter.</response></match><match order="2"><premise>const</premise><response>indicates a variable or value is unchanging.</response></match><match order="3"><premise>function </premise><response> Section of code that performs a procedure and usually is named meaningfully.</response></match><match order="4"><premise>overloading</premise><response>Specifying more than one definition for the same function name.</response></match><match order="5"><premise>parameter</premise><response>Variable in a function or method definition that accepts data passed from an argument.</response></match><match order="6"><premise>reference</premise><response>Value that indicates an address in a computer's memory.</response></match><match order="7"><premise>void</premise><response>indicates a function has no return value.</response></match></matches></exercise>      </reading-questions>   
     </section>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
I removed checkpoints across chapter four, and I also labeled the multiple choice problems as reading questions at the end of the section where they belong to know they show up as reading questions instead of checkpoints. also, many active code was showing as a checkpoint. I removed the checkpoint from the active code, too.

## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
fix #125 
## How Has This Been Tested?
1. Make changes locally.
2. Verify the changes.
![image](https://github.com/pearcej/cpp4python/assets/117699634/0824a1c0-cf95-46ba-9d9e-bbee234ba8f8)
![image](https://github.com/pearcej/cpp4python/assets/117699634/dbfbacdb-40dc-400e-9757-c9a96b82ad5c)
