### PR TITLE
Remove checkpoints across chapter 5 (cpp4python-v2)

### DIFF
--- a/pretext/CollectionData/Arrays.ptx
+++ b/pretext/CollectionData/Arrays.ptx
@@ -59,7 +59,7 @@ double ddouble = 1.2;     // cannot use index to access value</pre>
             help you better understand the trade-offs of the
             protections Python offers.</p>
         <p>Here are examples of iteration.</p>
-       ]<TabNode tabname="C++" tabnode_options="{'subchapter': 'Arrays', 'chapter': 'CollectionData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
+       <TabNode tabname="C++" tabnode_options="{'subchapter': 'Arrays', 'chapter': 'CollectionData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
 
     <program xml:id="listarray_cpp" interactive="activecode" language="cpp">
         <input>

--- a/pretext/CollectionData/Arrays.ptx
+++ b/pretext/CollectionData/Arrays.ptx
@@ -59,7 +59,7 @@ double ddouble = 1.2;     // cannot use index to access value</pre>
             help you better understand the trade-offs of the
             protections Python offers.</p>
         <p>Here are examples of iteration.</p>
-        <exercise ><TabNode tabname="C++" tabnode_options="{'subchapter': 'Arrays', 'chapter': 'CollectionData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
+       ]<TabNode tabname="C++" tabnode_options="{'subchapter': 'Arrays', 'chapter': 'CollectionData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
 
     <program xml:id="listarray_cpp" interactive="activecode" language="cpp">
         <input>
@@ -92,7 +92,7 @@ def main():
 main()
         </input>
     </program>
-            </TabNode></exercise>
+            </TabNode>
         <p>The protections Python offers, however, takes time and C++ is designed for speed.
             Python would never let you iterate beyond the end of
             a list. C++ will not only let you iterate beyond either
@@ -102,7 +102,7 @@ main()
         <p>The phrase, <q>be careful what you wish for</q> is a great one
             to remember when programming in C++. Because C++ will
             generally try to do everything you ask for.</p>
-        <exercise ><TabNode tabname="C++" tabnode_options="{'subchapter': 'Arrays', 'chapter': 'CollectionData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
+       <TabNode tabname="C++" tabnode_options="{'subchapter': 'Arrays', 'chapter': 'CollectionData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
 
     <program xml:id="array_error_cpp" interactive="activecode" language="cpp">
         <input>
@@ -139,14 +139,14 @@ def main():
 main()
         </input>
     </program>
-            </TabNode></exercise>
+            </TabNode>
         <p>The speed of C++ comes at the cost of minimal to no error checking.
             Sometimes this can have perplexing results such as in the next example.</p>
         <p>You should use an array when you have a need for speed
             or you need to work with hardware constraints.
             Otherwise, you may want to consider using another collection data type,
             the <em>vector</em>.</p>
-        <exercise ><TabNode tabname="C++" tabnode_options="{'subchapter': 'Arrays', 'chapter': 'CollectionData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
+        <TabNode tabname="C++" tabnode_options="{'subchapter': 'Arrays', 'chapter': 'CollectionData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
 
     <program xml:id="array_werror_cpp" interactive="activecode" language="cpp">
         <input>
@@ -196,12 +196,15 @@ def main():
 main()
         </input>
     </program>
-            </TabNode></exercise>
+            </TabNode>
+<reading-questions xml:id="rqs-arrays">
+    <title>Reading Questions</title>
+    
 
     <exercise label="mc_werror">
         <statement>
 
-        <p>Q-7: In the above example, what happened to otherdata[ ] in C++?</p>
+        <p>In the above example, what happened to otherdata[ ] in C++?</p>
 
         </statement>
 <choices>
@@ -257,7 +260,7 @@ main()
     <exercise label="mc_array">
         <statement>
 
-        <p>Q-8: What is the correct way to declare an array in C++?</p>
+        <p>What is the correct way to declare an array in C++?</p>
 
         </statement>
 <choices>
@@ -300,5 +303,7 @@ main()
 </choices>
 
     </exercise>
+        
+</reading-questions>
     </section>
 

--- a/pretext/CollectionData/HashTables.ptx
+++ b/pretext/CollectionData/HashTables.ptx
@@ -21,7 +21,7 @@
             key-value pairs can also be added later as we see in the following example.
             In C++, the keyword <c>first</c> is used for the key, and <c>second</c> is used for the
             associated value.</p>
-        <exercise ><TabNode tabname="C++" tabnode_options="{'subchapter': 'HashTables', 'chapter': 'CollectionData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
+        <TabNode tabname="C++" tabnode_options="{'subchapter': 'HashTables', 'chapter': 'CollectionData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
 
     <program xml:id="hashtable1_cpp" interactive="activecode" language="cpp">
         <input>
@@ -68,7 +68,7 @@ def main():
 main()
         </input>
     </program>
-            </TabNode></exercise>
+            </TabNode>
         <p>It is important to note that hash tables are organized by the location given
             by the hash function rather than being in any
             particular order with respect to the keys. This makes look-up extremely fast.
@@ -78,7 +78,7 @@ main()
             Iterators of an <c>unordered_map</c> are
             implemented using pointers to point to elements of the value type as we see in
             the following example.</p>
-        <exercise ><TabNode tabname="C++" tabnode_options="{'subchapter': 'HashTables', 'chapter': 'CollectionData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
+       <TabNode tabname="C++" tabnode_options="{'subchapter': 'HashTables', 'chapter': 'CollectionData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
 
     <program xml:id="hashtable2_cpp" interactive="activecode" language="cpp">
         <input>
@@ -123,7 +123,7 @@ def main():
 main()
         </input>
     </program>
-            </TabNode></exercise>
+            </TabNode>
         <p>Hash Tables have both methods and operators. <xref ref="collection-data_collection-data_tab-hashopers"/>
             describes them, and the session shows them in action.</p>
         
@@ -205,12 +205,14 @@ main()
                 
             
         </tabular></table>
-        <subsection xml:id="collection-data_matching">
-            <title>Matching</title>
+<reading-questions xml:id="rqs-hashtable">
+    <title>Reading Question</title>
+    
+    
 
 <exercise label="matching_HT">
     <statement><p> Match the Hash Table operations with their corresponding explination.</p></statement>
     <feedback><p>Feedback shows incorrect matches.</p></feedback>
-<matches><match order="1"><premise>[ ]</premise><response>Returns the value associated with the key, otherwise throws error.</response></match><match order="2"><premise>erase</premise><response>Deletes the entry from the hash table.</response></match><match order="3"><premise>count</premise><response>Returns true if key is in the hash table, and false otherwise.</response></match><match order="4"><premise>begin</premise><response>An iterator to the first element in the hash table.</response></match><match order="5"><premise>end</premise><response>An iterator pointing to past-the-end element of the hash table.</response></match></matches></exercise>        </subsection>
+<matches><match order="1"><premise>[ ]</premise><response>Returns the value associated with the key, otherwise throws error.</response></match><match order="2"><premise>erase</premise><response>Deletes the entry from the hash table.</response></match><match order="3"><premise>count</premise><response>Returns true if key is in the hash table, and false otherwise.</response></match><match order="4"><premise>begin</premise><response>An iterator to the first element in the hash table.</response></match><match order="5"><premise>end</premise><response>An iterator pointing to past-the-end element of the hash table.</response></match></matches></exercise>  </reading-questions>      
     </section>
 

--- a/pretext/CollectionData/Strings.ptx
+++ b/pretext/CollectionData/Strings.ptx
@@ -12,52 +12,7 @@ char cstring[] = {"Hello World!"};    // C-string or char array uses double quot
             C++ (from C++11 onward), however, you can use a C++ string for everything.
             Since C++ strings are so much nicer and similar to Python strings, I would not recommend using C-strings.</p>
 
-    <exercise label="cstringquestion1_1">
-        <statement>
-
-        <p>Q-1: What is the correct definition of c-strings?</p>
-
-        </statement>
-<choices>
-
-            <choice correct="yes">
-                <statement>
-                    <p>An array of characters that ends with a terminating null character. i.e. \0</p>
-                </statement>
-                <feedback>
-                    <p>Correct! a c-string is different from a string</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>A sequential data structure consisting of zero or more characters</p>
-                </statement>
-                <feedback>
-                    <p>Close, but that is the definition of a string, not a c-string</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>A data structure consisting of an ordered collection of data elements of identical type in which each element can be identified by an array index.</p>
-                </statement>
-                <feedback>
-                    <p>Sorry, thats not a string or a c-string</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>sequence container storing data of a single type that is stored in a dynamically allocated array which can change in size.</p>
-                </statement>
-                <feedback>
-                    <p>No, that's a vector</p>
-                </feedback>
-            </choice>
-</choices>
-
-    </exercise>
+    
         <p>Because strings are sequences, all of the typical sequence operations work as you would expect.
             In addition, the string library offers a huge number of
             methods, some of the most useful of which are shown in <xref ref="collection-data_collection-data_tab-stringmethods"/>.</p>
@@ -195,13 +150,9 @@ char cstring[] = {"Hello World!"};    // C-string or char array uses double quot
                 
             
         </tabular></table>
-        <subsection xml:id="collection-data_matching">
-            <title>Matching</title>
+      
 
-<exercise label="matching_strings">
-    <statement><p> Match the String operations with their corresponding explination.</p></statement>
-    <feedback><p>Feedback shows incorrect matches.</p></feedback>
-<matches><match order="1"><premise>[ ]</premise><response>Accesses value of an element.</response></match><match order="10"><premise>find</premise><response> Returns the index of the first occurrence of item.</response></match><match order="2"><premise>=</premise><response> Assigns value to an element.</response></match><match order="3"><premise>push_back</premise><response>Adjoins a character to the end of the string.</response></match><match order="4"><premise>pop_back</premise><response>Removes the last character from the end of the string.</response></match><match order="5"><premise>insert</premise><response>Injects a string at a specific index.</response></match><match order="6"><premise>erase</premise><response>Deletes an element from one index to another.</response></match><match order="7"><premise>size</premise><response>Returns the capacity of the string.</response></match><match order="8"><premise>+</premise><response>connects strings.</response></match><match order="9"><premise>append</premise><response>Adjoins a string to the end of the string.</response></match></matches></exercise>            <exercise ><TabNode tabname="C++" tabnode_options="{'subchapter': 'Strings', 'chapter': 'CollectionData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
+            <TabNode tabname="C++" tabnode_options="{'subchapter': 'Strings', 'chapter': 'CollectionData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
 
     <program xml:id="introstring_cpp" interactive="activecode" language="cpp">
         <input>
@@ -246,12 +197,67 @@ def main():
 main()
         </input>
     </program>
-                </TabNode></exercise>
+                </TabNode>
             <p>Check your understanding by completing the following question.</p>
 
-<exercise label="string_types">
-    <statement><p>Drag each data type to its' corresponding C++ initialization syntax.</p></statement>
-    <feedback><p>Feedback shows incorrect matches.</p></feedback>
-<matches><match order="1"><premise>char</premise><response>'a'</response></match><match order="2"><premise>char array</premise><response>{'a'}</response></match><match order="3"><premise>string</premise><response>"a"</response></match></matches></exercise>        </subsection>
+
+
+<reading-questions xml:id="rqs-strings">
+    <title>Reading Questions</title>
+    <exercise label="cstringquestion1_1">
+        <statement>
+
+        <p>What is the correct definition of c-strings?</p>
+
+        </statement>
+<choices>
+
+            <choice correct="yes">
+                <statement>
+                    <p>An array of characters that ends with a terminating null character. i.e. \0</p>
+                </statement>
+                <feedback>
+                    <p>Correct! a c-string is different from a string</p>
+                </feedback>
+            </choice>
+
+            <choice>
+                <statement>
+                    <p>A sequential data structure consisting of zero or more characters</p>
+                </statement>
+                <feedback>
+                    <p>Close, but that is the definition of a string, not a c-string</p>
+                </feedback>
+            </choice>
+
+            <choice>
+                <statement>
+                    <p>A data structure consisting of an ordered collection of data elements of identical type in which each element can be identified by an array index.</p>
+                </statement>
+                <feedback>
+                    <p>Sorry, thats not a string or a c-string</p>
+                </feedback>
+            </choice>
+
+            <choice>
+                <statement>
+                    <p>sequence container storing data of a single type that is stored in a dynamically allocated array which can change in size.</p>
+                </statement>
+                <feedback>
+                    <p>No, that's a vector</p>
+                </feedback>
+            </choice>
+</choices>
+
+    </exercise>
+    <exercise label="matching_strings">
+        <statement><p> Match the String operations with their corresponding explination.</p></statement>
+        <feedback><p>Feedback shows incorrect matches.</p></feedback>
+    <matches><match order="1"><premise>[ ]</premise><response>Accesses value of an element.</response></match><match order="10"><premise>find</premise><response> Returns the index of the first occurrence of item.</response></match><match order="2"><premise>=</premise><response> Assigns value to an element.</response></match><match order="3"><premise>push_back</premise><response>Adjoins a character to the end of the string.</response></match><match order="4"><premise>pop_back</premise><response>Removes the last character from the end of the string.</response></match><match order="5"><premise>insert</premise><response>Injects a string at a specific index.</response></match><match order="6"><premise>erase</premise><response>Deletes an element from one index to another.</response></match><match order="7"><premise>size</premise><response>Returns the capacity of the string.</response></match><match order="8"><premise>+</premise><response>connects strings.</response></match><match order="9"><premise>append</premise><response>Adjoins a string to the end of the string.</response></match></matches></exercise>
+    <exercise label="string_types">
+        <statement><p>Drag each data type to its' corresponding C++ initialization syntax.</p></statement>
+        <feedback><p>Feedback shows incorrect matches.</p></feedback>
+    <matches><match order="1"><premise>char</premise><response>'a'</response></match><match order="2"><premise>char array</premise><response>{'a'}</response></match><match order="3"><premise>string</premise><response>"a"</response></match></matches></exercise>
+</reading-questions>
     </section>
 

--- a/pretext/CollectionData/UnorderedSet.ptx
+++ b/pretext/CollectionData/UnorderedSet.ptx
@@ -140,12 +140,15 @@ return 0;
             <c>set.find(letter) == set.end()</c> section means that if <c>find</c> cannot
             find the <c>letter</c> before reaching the end of the set, then <c>letter</c>
             is not contained in the set.</p>
-        <subsection xml:id="collection-data_matching">
-            <title>Matching</title>
+
+<reading-questions xml:id="rqs-unorder-set">
+    <title>Reading Question</title>
+    
+    
 
 <exercise label="matching_us">
     <statement><p> Match the Unordered Sets operations with their corresponding explination.</p></statement>
     <feedback><p>Feedback shows incorrect matches.</p></feedback>
-<matches><match order="1"><premise>union</premise><response>Returns a new set with all elements from both sets.</response></match><match order="2"><premise>intersection</premise><response>Returns a new set with only those elements common to both sets.</response></match><match order="3"><premise>difference</premise><response> Returns a new set with all items from first set not in second.</response></match><match order="4"><premise>add</premise><response>Adds item to the set.</response></match><match order="5"><premise>remove</premise><response>erases item from the set.</response></match><match order="6"><premise>clear</premise><response>Removes all elements from the set.</response></match></matches></exercise>        </subsection>
+<matches><match order="1"><premise>union</premise><response>Returns a new set with all elements from both sets.</response></match><match order="2"><premise>intersection</premise><response>Returns a new set with only those elements common to both sets.</response></match><match order="3"><premise>difference</premise><response> Returns a new set with all items from first set not in second.</response></match><match order="4"><premise>add</premise><response>Adds item to the set.</response></match><match order="5"><premise>remove</premise><response>erases item from the set.</response></match><match order="6"><premise>clear</premise><response>Removes all elements from the set.</response></match></matches></exercise>  </reading-questions>     
     </section>
     

--- a/pretext/CollectionData/Vectors.ptx
+++ b/pretext/CollectionData/Vectors.ptx
@@ -191,10 +191,7 @@ int main() {
             <subsubsection xml:id="collection-data_matching">
                 <title>Matching</title>
 
-<exercise label="matching_vectors">
-    <statement><p> Match the Vector operations with their corresponding explination.</p></statement>
-    <feedback><p>Feedback shows incorrect matches.</p></feedback>
-<matches><match order="1"><premise>[ ]</premise><response>Accesses value of an element.</response></match><match order="2"><premise>=</premise><response> Assigns value to an element.</response></match><match order="3"><premise>push_back</premise><response>Appends item to the end of the vector.</response></match><match order="4"><premise>pop_back</premise><response> Deletes last item of the vector.</response></match><match order="5"><premise>insert</premise><response>Injects an item into the vector.</response></match><match order="6"><premise>erase</premise><response>Deletes an element from the choosen index.</response></match><match order="7"><premise>size</premise><response>Returns the actual capacity used by elements.</response></match><match order="8"><premise>capacity</premise><response>Returns the ammount of allocated storage space.</response></match><match order="9"><premise>reserve</premise><response> Request a change in space to amount</response></match></matches></exercise>                <exercise ><TabNode tabname="C++" tabnode_options="{'subchapter': 'Vectors', 'chapter': 'CollectionData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
+               <TabNode tabname="C++" tabnode_options="{'subchapter': 'Vectors', 'chapter': 'CollectionData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
 
     <program xml:id="introvector_cpp" interactive="activecode" language="cpp">
         <input>
@@ -233,7 +230,7 @@ def main():
 main()
         </input>
     </program>
-                    </TabNode></exercise>
+                    </TabNode>
                 <p>In the above example, the use of <c>reserve</c> was optional. However, it is a good
                     idea to use it before growing a vector in this way because it will save time.
                     Because vectors are stored in underlying arrays which require contiguous memory,
@@ -268,7 +265,7 @@ int main(){
     </program>
                 <p>Remembering that C++ is designed for speed, not protection,
                     we will likely not be surprised by the following:</p>
-                <exercise ><TabNode tabname="C++" tabnode_options="{'subchapter': 'Vectors', 'chapter': 'CollectionData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
+                <TabNode tabname="C++" tabnode_options="{'subchapter': 'Vectors', 'chapter': 'CollectionData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
 
     <program xml:id="vector_errors_cpp" interactive="activecode" language="cpp">
         <input>
@@ -315,12 +312,19 @@ def main():
 main()
         </input>
     </program>
-                    </TabNode></exercise>
-
+                    </TabNode>
+                    
+                    
+                    <reading-questions xml:id="rqs-vectors">
+                        <title>Reading Questions</title>
+                    <exercise label="matching_vectors">
+                        <statement><p> Match the Vector operations with their corresponding explination.</p></statement>
+                        <feedback><p>Feedback shows incorrect matches.</p></feedback>
+                    <matches><match order="1"><premise>[ ]</premise><response>Accesses value of an element.</response></match><match order="2"><premise>=</premise><response> Assigns value to an element.</response></match><match order="3"><premise>push_back</premise><response>Appends item to the end of the vector.</response></match><match order="4"><premise>pop_back</premise><response> Deletes last item of the vector.</response></match><match order="5"><premise>insert</premise><response>Injects an item into the vector.</response></match><match order="6"><premise>erase</premise><response>Deletes an element from the choosen index.</response></match><match order="7"><premise>size</premise><response>Returns the actual capacity used by elements.</response></match><match order="8"><premise>capacity</premise><response>Returns the ammount of allocated storage space.</response></match><match order="9"><premise>reserve</premise><response> Request a change in space to amount</response></match></matches></exercise> 
     <exercise label="mc_array_vector">
         <statement>
 
-                <p>Q-8: Which of the following is the biggest difference between a C++ array and a C++ vector?</p>
+                <p>Which of the following is the biggest difference between a C++ array and a C++ vector?</p>
 
         </statement>
 <choices>
@@ -373,10 +377,12 @@ main()
 
     </exercise>
 
+    
+    
     <exercise label="mc_vector1">
         <statement>
 
-                <p>Q-9: What good is the <c>reserve</c> method in a vector?</p>
+                <p>What good is the <c>reserve</c> method in a vector?</p>
 
         </statement>
 <choices>
@@ -419,6 +425,7 @@ main()
 </choices>
 
     </exercise>
+</reading-questions>
             </subsubsection>
         </subsection>
     </section>

--- a/pretext/CollectionData/Vectors.ptx
+++ b/pretext/CollectionData/Vectors.ptx
@@ -17,11 +17,7 @@
         
         <table xml:id="collection-data_id1"><tabular>
             <title><term>Common C++ Vector Operators</term></title>
-            
-                
-                
-                
-                
+        
                     <row header="yes">
                         <cell>
                             <term>Vector Operation</term>
@@ -188,9 +184,6 @@ int main() {
                     
                 </li>
             </dl>
-            <subsubsection xml:id="collection-data_matching">
-                <title>Matching</title>
-
                <TabNode tabname="C++" tabnode_options="{'subchapter': 'Vectors', 'chapter': 'CollectionData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
 
     <program xml:id="introvector_cpp" interactive="activecode" language="cpp">
@@ -426,7 +419,6 @@ main()
 
     </exercise>
 </reading-questions>
-            </subsubsection>
         </subsection>
     </section>
 

--- a/pretext/CollectionData/glossary.ptx
+++ b/pretext/CollectionData/glossary.ptx
@@ -58,12 +58,15 @@
                 </gi>
             
         </glossary>
-        <subsection xml:id="collection-data_matching">
-            <title>Matching</title>
+<reading-questions xml:id="rqs-glossary5">
+    <title>Reading Question</title>
+    
+    
+
 
 <exercise label="matching_ch5">
     <statement><p>Match the words to thier corresponding definition.</p></statement>
     <feedback><p>Feedback shows incorrect matches.</p></feedback>
-<matches><match order="1"><premise>array</premise><response>a data structure consisting of an ordered collection of data elements of identical type in which each element can be identified by an index.</response></match><match order="2"><premise>collection</premise><response> a grouping of a number of data items that have some shared significance or need to be operated upon together.</response></match><match order="3"><premise>vector</premise><response>sequence container storing data of a single type that is stored in a dynamically allocated array which can change in size.</response></match><match order="4"><premise>hash table</premise><response>a collection consisting of key-value pairs with an associated function that maps the key to the associated value.</response></match><match order="5"><premise>set</premise><response>An unordered data structure consisting of unique, immutable data values.</response></match><match order="6"><premise>string</premise><response>A sequential data structure consisting of zero or more characters.</response></match><match order="7"><premise>word</premise><response>unit of data used by a particular processor design.</response></match><match order="8"><premise>mutability</premise><response>able to be modified.</response></match><match order="9"><premise>immutable</premise><response>unable to be modified.</response></match></matches></exercise>        </subsection>
+<matches><match order="1"><premise>array</premise><response>a data structure consisting of an ordered collection of data elements of identical type in which each element can be identified by an index.</response></match><match order="2"><premise>collection</premise><response> a grouping of a number of data items that have some shared significance or need to be operated upon together.</response></match><match order="3"><premise>vector</premise><response>sequence container storing data of a single type that is stored in a dynamically allocated array which can change in size.</response></match><match order="4"><premise>hash table</premise><response>a collection consisting of key-value pairs with an associated function that maps the key to the associated value.</response></match><match order="5"><premise>set</premise><response>An unordered data structure consisting of unique, immutable data values.</response></match><match order="6"><premise>string</premise><response>A sequential data structure consisting of zero or more characters.</response></match><match order="7"><premise>word</premise><response>unit of data used by a particular processor design.</response></match><match order="8"><premise>mutability</premise><response>able to be modified.</response></match><match order="9"><premise>immutable</premise><response>unable to be modified.</response></match></matches></exercise>     </reading-questions>   
     </section>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
I removed checkpoints across chapter five, and I also labeled the multiple choice problems as reading questions at the end of the section where they belong to know they show up as reading questions instead of checkpoints. also, many active code was showing as a checkpoint. I removed the checkpoint from the active code, too.

## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
fix #126
## How Has This Been Tested?
1. Make changes locally.
2. Verify the changes.
![image](https://github.com/pearcej/cpp4python/assets/117699634/a750180e-1228-47df-a2e4-a257448bbe17)
![image](https://github.com/pearcej/cpp4python/assets/117699634/106c94a9-e2f9-432f-8dd0-1e055c32f6ee)
