### PR TITLE
Remove checkpoints across chapter 6 (cpp4python-v2)

### DIFF
--- a/pretext/Input_and_Output/FileOperations.ptx
+++ b/pretext/Input_and_Output/FileOperations.ptx
@@ -16,11 +16,13 @@
         <p>To close the file for <c>out_stream</c>, we use its <c>close()</c> function, which also adds an end-of-file marker to indicate where the end of the file is:</p>
         <pre>out_stream.close();</pre>
         <p>Answer the question below concerning the use of the <c>fstream</c> library:</p>
+<reading-questions xml:id="rqs-file-operations">
+    <title>Reading Question</title>
 
     <exercise label="stream_library_1">
         <statement>
 
-        <p>Q-1: Say you wanted to add some text to a file that already has important information on it.
+        <p>Say you wanted to add some text to a file that already has important information on it.
             Would it be a good idea to first use <c>ofstream</c> to open the file?</p>
 
         </statement>
@@ -64,5 +66,6 @@
 </choices>
 
     </exercise>
+</reading-questions>
     </section>
 

--- a/pretext/Input_and_Output/Summary.ptx
+++ b/pretext/Input_and_Output/Summary.ptx
@@ -14,13 +14,14 @@
                 <p>End-of-File or <c>.eof()</c> is a method for the instance variables of fstream, input and output stream objects, and can be used to carry out a task until a file has ended or do some task after a file has ended.</p>
             </li>
         </ol></p>
-        <subsection xml:id="input_and_-output_check-yourself">
-            <title>Check Yourself</title>
-
+        <reading-questions xml:id="rqs-summary6">
+            <title>Reading Questions</title>
+            
+            
     <exercise label="stream_library_2">
         <statement>
 
-            <p>Q-1: Which of the following are libraries for C++ input and output? (Choose all that are true.)</p>
+            <p>Which of the following are libraries for C++ input and output? (Choose all that are true.)</p>
 
         </statement>
 <choices>
@@ -70,7 +71,7 @@
 <matches><match order="1"><premise>fstream</premise><response>I want to write to a file</response></match><match order="2"><premise>iostream</premise><response>I want to write to the console</response></match></matches></exercise>
         <exercise>
             <statement>
-    <p>Q-3: Fill in the blank with the value of <c>inputn</c> when the following code runs. <var/>  </p></statement><setup><var><pre>#include &lt;fstream&gt;
+    <p>Fill in the blank with the value of <c>inputn</c> when the following code runs. <var/>  </p></statement><setup><var><pre>#include &lt;fstream&gt;
 #include &lt;cstdlib&gt;
 #include &lt;iostream&gt;
 using namespace std;
@@ -89,6 +90,7 @@ main(){
   in_stream &gt;&gt; inputn;
   cout &lt;&lt; inputn;
   in_stream &gt;&gt; inputn;
-}</pre><condition number="[101, 101]"><feedback><p>That is the correct answer! Good job!</p></feedback></condition><condition number="[25, 25]"><feedback><p>No. Hint: <c>inputn</c> is changed twice.</p></feedback></condition><condition number="[2515, 2515]"><feedback><p>No. Hint: <c>inputn</c> is changed twice.</p></feedback></condition><condition number="[15, 15]"><feedback><p>No. Hint: note that there is no space between the first 25 and 15!</p></feedback></condition></var></setup></exercise>        </subsection>
+}</pre><condition number="[101, 101]"><feedback><p>That is the correct answer! Good job!</p></feedback></condition><condition number="[25, 25]"><feedback><p>No. Hint: <c>inputn</c> is changed twice.</p></feedback></condition><condition number="[2515, 2515]"><feedback><p>No. Hint: <c>inputn</c> is changed twice.</p></feedback></condition><condition number="[15, 15]"><feedback><p>No. Hint: note that there is no space between the first 25 and 15!</p></feedback></condition></var></setup></exercise> 
+</reading-questions>
     </section>
 

--- a/pretext/Input_and_Output/TheEOF.ptx
+++ b/pretext/Input_and_Output/TheEOF.ptx
@@ -113,11 +113,13 @@ void make_neat(
     &lt;iframe height="400px" width="100%" src="https://repl.it/@CodyWMitchell/File-Handling-2?lite=true" scrolling="no" frameborder="no" allowtransparency="true" allowfullscreen="true" sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-modals"&gt;&lt;/iframe&gt;
 &lt;/div&gt;</raw>
         <p>The input file <c>rawdata.txt</c> must be in the same directory (folder) as the program in order for it to open successfully. The program will create a file called <q>neat.dat</q> to output the results.</p>
-
+<reading-questions xml:id="rqs-the-eof">
+    <title>Reading Question</title>
+    
     <exercise label="eofFirst">
         <statement>
 
-        <p>Q-1: What are good use cases for EOFs in C++ programming?</p>
+        <p>What are good use cases for EOFs in C++ programming?</p>
 
         </statement>
 <choices>
@@ -160,5 +162,7 @@ void make_neat(
 </choices>
 
     </exercise>
+</reading-questions>
+
     </section>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
I removed checkpoints across chapter six, and I also labeled the multiple choice problems as reading questions at the end of the section where they belong to know they show up as reading questions instead of checkpoints. also, many active code was showing as a checkpoint. I removed the checkpoint from the active code, too.

## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
fix #127 
## How Has This Been Tested?
1. Make changes locally.
2. Verify the changes.
![image](https://github.com/pearcej/cpp4python/assets/117699634/dddf9924-e492-4b37-8927-3564974fe0ec)
![image](https://github.com/pearcej/cpp4python/assets/117699634/f52dab5e-e4fa-4659-afea-97713b093297)
