### PR TITLE
Remove checkpoints across chapter 8 (cpp4python-v2)

### DIFF
--- a/pretext/Turtles/advanced_features.ptx
+++ b/pretext/Turtles/advanced_features.ptx
@@ -107,62 +107,65 @@ int main(){
 }
 </input></program>
 
-    <exercise label="cturtle_advanced_mchoice_1">
-        <statement>
-
-        <p>Q-1: How many frames of animation does the above code create?</p>
-
-        </statement>
-<choices>
-
-            <choice>
-                <statement>
-                    <p>3</p>
-                </statement>
-                <feedback>
-                    <p>Incorrect! Consider how many actions the turtle takes in the for loop.</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>6</p>
-                </statement>
-                <feedback>
-                    <p>Incorrect! Consider the tracer setting for the screen.</p>
-                </feedback>
-            </choice>
-
-            <choice correct="yes">
-                <statement>
-                    <p>1</p>
-                </statement>
-                <feedback>
-                    <p>Correct!</p>
-                </feedback>
-            </choice>
-
-            <choice>
-                <statement>
-                    <p>12</p>
-                </statement>
-                <feedback>
-                    <p>Incorrect! Consider how many actions the turtle takes in the for loop.</p>
-                </feedback>
-            </choice>
-</choices>
-
-    </exercise>
+    
         <p>Similarly to tracer settings, every action a turtle takes is also added to the <em>undo queue</em>. This allows it to keep track
             of actions it is performing over a period of time. The queue is only allowed to grow to a certain size, starting at 100 actions total.
             This is modifiable through the <c classes="code">setundobuffer</c> method that belongs to turtles. Every action is added, even if
             the action doesn't change anything visually. This feature is comparable to the <q>undo</q> tool available in most text editors.
             Turtles can <q>undo</q> their progress with the <c classes="code">undo</c> method.</p>
-
+           
+            <reading-questions xml:id="rqs-advanced-features">
+                <title>Reading Questions</title>
+            <exercise label="cturtle_advanced_mchoice_1">
+                <statement>
+        
+                <p>How many frames of animation does the above code create?</p>
+        
+                </statement>
+        <choices>
+        
+                    <choice>
+                        <statement>
+                            <p>3</p>
+                        </statement>
+                        <feedback>
+                            <p>Incorrect! Consider how many actions the turtle takes in the for loop.</p>
+                        </feedback>
+                    </choice>
+        
+                    <choice>
+                        <statement>
+                            <p>6</p>
+                        </statement>
+                        <feedback>
+                            <p>Incorrect! Consider the tracer setting for the screen.</p>
+                        </feedback>
+                    </choice>
+        
+                    <choice correct="yes">
+                        <statement>
+                            <p>1</p>
+                        </statement>
+                        <feedback>
+                            <p>Correct!</p>
+                        </feedback>
+                    </choice>
+        
+                    <choice>
+                        <statement>
+                            <p>12</p>
+                        </statement>
+                        <feedback>
+                            <p>Incorrect! Consider how many actions the turtle takes in the for loop.</p>
+                        </feedback>
+                    </choice>
+        </choices>
+        
+            </exercise>
     <exercise label="cturtle_advanced_mchoice_2">
         <statement>
 
-        <p>Q-2: How many actions will be in the turtle's undo queue for the code above?</p>
+        <p>How many actions will be in the turtle's undo queue for the code above?</p>
 
         </statement>
 <choices>
@@ -205,5 +208,9 @@ int main(){
 </choices>
 
     </exercise>
+
+        
+        
+    </reading-questions>
     </section>
 

--- a/pretext/Turtles/check_yourself.ptx
+++ b/pretext/Turtles/check_yourself.ptx
@@ -1,6 +1,9 @@
 <section xml:id="turtles_check-yourself">
         <title>Check Yourself</title>
-
+<reading-questions xml:id="rqs-check-yourself8">
+    <title>Reading Questions</title>
+    
+    
     <program xml:id="turtle_checkyourself_ac_1" interactive="activecode" language="cpp">
         <input>
 #include &lt;CTurtle.hpp&gt;
@@ -28,7 +31,7 @@ int main() {
     <exercise label="turtle_checkyourself_mchoice_1">
         <statement>
 
-        <p>Q-2: How large would the undo queue be for the above code example?</p>
+        <p>How large would the undo queue be for the above code example?</p>
 
         </statement>
 <choices>
@@ -92,7 +95,7 @@ int main() {
     <exercise label="turtle_checkyourself_mchoice_2">
         <statement>
 
-        <p>Q-3: What kind of shape does the above activecode create?</p>
+        <p>What kind of shape does the above activecode create?</p>
 
         </statement>
 <choices>
@@ -139,7 +142,7 @@ int main() {
     <exercise label="turtle_checkyourself_mchoice_3">
         <statement>
 
-        <p>Q-4: You can have more than one turtle on one screen.</p>
+        <p>You can have more than one turtle on one screen.</p>
 
         </statement>
 <choices>
@@ -164,5 +167,6 @@ int main() {
 </choices>
 
     </exercise>
+</reading-questions>
     </section>
 

--- a/pretext/Turtles/glossary.ptx
+++ b/pretext/Turtles/glossary.ptx
@@ -100,13 +100,16 @@
                 </gi>
             
         </glossary>
-        <subsection xml:id="turtles_matching">
-            <title>Matching</title>
+<reading-questions xml:id="rqs-glossary8">
+    <title>Reading Question</title>
+    
+    
 
 <exercise label="cturtle_dnd_glossary">
     <statement><p>
 </p></statement>
     
-<matches><match order="1"><premise>what color to fill drawing with.</premise><response>turtle.fillcolor</response></match><match order="10"><premise>write some text to the canvas.</premise><response>turtle.write</response></match><match order="2"><premise>start filling the shape.</premise><response>turtle.beginfill</response></match><match order="3"><premise>stops filling the shape.</premise><response>turtle.endfill</response></match><match order="4"><premise>change the paintbrush color.</premise><response>turtle.pencolor</response></match><match order="5"><premise>change the paintbrush size.</premise><response>turtle.width</response></match><match order="6"><premise>change the speed</premise><response>turtle.speed</response></match><match order="7"><premise>move backward.</premise><response>turtle.back</response></match><match order="8"><premise>move forward.</premise><response>turtle.forward</response></match><match order="9"><premise>move to a specific coordinate.</premise><response>turtle.goto</response></match></matches></exercise>        </subsection>
+<matches><match order="1"><premise>what color to fill drawing with.</premise><response>turtle.fillcolor</response></match><match order="10"><premise>write some text to the canvas.</premise><response>turtle.write</response></match><match order="2"><premise>start filling the shape.</premise><response>turtle.beginfill</response></match><match order="3"><premise>stops filling the shape.</premise><response>turtle.endfill</response></match><match order="4"><premise>change the paintbrush color.</premise><response>turtle.pencolor</response></match><match order="5"><premise>change the paintbrush size.</premise><response>turtle.width</response></match><match order="6"><premise>change the speed</premise><response>turtle.speed</response></match><match order="7"><premise>move backward.</premise><response>turtle.back</response></match><match order="8"><premise>move forward.</premise><response>turtle.forward</response></match><match order="9"><premise>move to a specific coordinate.</premise><response>turtle.goto</response></match></matches></exercise>        </reading-questions>
+
     </section>
 

--- a/pretext/Turtles/introduction.ptx
+++ b/pretext/Turtles/introduction.ptx
@@ -80,11 +80,12 @@ for i in range(4):
 turt.end_fill()
         </input>
     </program>
-
+<reading-questions xml:id="rqs-introduction">
+    <title>Reading Question</title>
     <exercise label="cturtle_question_1">
         <statement>
 
-            <p>Q-3: How might students benefit from having a visual representation such as C-Turtle? Check all that apply.</p>
+            <p>How might students benefit from having a visual representation such as C-Turtle? Check all that apply.</p>
 
         </statement>
 <choices>
@@ -127,6 +128,7 @@ turt.end_fill()
 </choices>
 
     </exercise>
+</reading-questions>
         </subsection>
     </section>
 

--- a/pretext/Turtles/turtle_and_turtlescreen.ptx
+++ b/pretext/Turtles/turtle_and_turtlescreen.ptx
@@ -278,7 +278,14 @@ int main() {
         <p>The order of operations given to a turtle is important, as some actions must be completed
             one after another. A good example of this is the <c classes="code">begin_fill</c> and <c classes="code">end_fill</c>
             pattern, which must be called in that specified order to actually fill a shape.</p>
-<exercise label="cturtle_question_3" indent="show" language="python"><statement>
+
+<reading-questions xml:id="rqs-turtle-and-turtle-screen">
+    <title>Reading Questions</title>
+    
+    
+
+
+            <exercise label="cturtle_question_3" indent="show" language="python"><statement>
         <p>Construct a program that fills a green triangle using begin_fill and end_fill
             using the example code above as a guide.</p>
 </statement>
@@ -313,5 +320,7 @@ int main() {
 <exercise label="cturtle_dnd_1">
     <statement><p>Match the turtle method descriptions to the methods they belong to.</p></statement>
     
-<matches><match order="1"><premise>turn to the left.</premise><response>turtle.left</response></match><match order="10"><premise>change the speed</premise><response>turtle.speed</response></match><match order="2"><premise>turn to the right.</premise><response>turtle.right</response></match><match order="3"><premise>pick pen up.</premise><response>turtle.penup</response></match><match order="4"><premise>put pen down.</premise><response>turtle.pendown</response></match><match order="5"><premise>what color to fill drawing with.</premise><response>turtle.fillcolor</response></match><match order="6"><premise>start filling the shape.</premise><response>turtle.beginfill</response></match><match order="7"><premise>stops filling the shape.</premise><response>turtle.endfill</response></match><match order="8"><premise>change the pen color.</premise><response>turtle.pencolor</response></match><match order="9"><premise>change the pen size.</premise><response>turtle.width</response></match></matches></exercise>    </section>
+<matches><match order="1"><premise>turn to the left.</premise><response>turtle.left</response></match><match order="10"><premise>change the speed</premise><response>turtle.speed</response></match><match order="2"><premise>turn to the right.</premise><response>turtle.right</response></match><match order="3"><premise>pick pen up.</premise><response>turtle.penup</response></match><match order="4"><premise>put pen down.</premise><response>turtle.pendown</response></match><match order="5"><premise>what color to fill drawing with.</premise><response>turtle.fillcolor</response></match><match order="6"><premise>start filling the shape.</premise><response>turtle.beginfill</response></match><match order="7"><premise>stops filling the shape.</premise><response>turtle.endfill</response></match><match order="8"><premise>change the pen color.</premise><response>turtle.pencolor</response></match><match order="9"><premise>change the pen size.</premise><response>turtle.width</response></match></matches></exercise>    
+</reading-questions>
+</section>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
I removed checkpoints across chapter eight, and I also labeled the multiple choice problems as reading questions at the end of the section where they belong to know they show up as reading questions instead of checkpoints. also, many active code was showing as a checkpoint. I removed the checkpoint from the active code, too.

## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
fix #129 
## How Has This Been Tested?
1. Make changes locally.
2. Verify the changes.
![image](https://github.com/pearcej/cpp4python/assets/117699634/c68eeb0e-b9eb-4e47-ae8a-3aad260f6e8a)
![image](https://github.com/pearcej/cpp4python/assets/117699634/e9e8ab15-e38a-46d0-9911-a1ee197eaf62)
