### PR TITLE
Make math symbols to show properly (cpp4python-v2)

### DIFF
--- a/pretext/AtomicData/BooleanData.ptx
+++ b/pretext/AtomicData/BooleanData.ptx
@@ -46,7 +46,7 @@ main()
     </program>
             </TabNode>
         <p>Boolean data objects are also used as results for comparison operators
-            such as equality (==) and greater than (<math>&gt;</math>). In addition,
+            such as equality (==) and greater than (<m>&gt;</m>). In addition,
             relational operators and logical operators can be combined together to
             form complex logical questions. <xref ref="atomic-data_id1"/> shows the relational
             and logical operators with examples shown in the session that follows.</p>
@@ -76,7 +76,7 @@ main()
                             less than
                         </cell>
                         <cell>
-                            <math>&lt;</math>
+                            <m>&lt;</m>
                         </cell>
                         <cell>
                             Less than operator
@@ -87,7 +87,7 @@ main()
                             greater than
                         </cell>
                         <cell>
-                            <math>&gt;</math>
+                            <m>&gt;</m>
                         </cell>
                         <cell>
                             Greater than operator
@@ -98,7 +98,7 @@ main()
                             less than or equal
                         </cell>
                         <cell>
-                            <math>&lt;=</math>
+                            <m>&lt;=</m>
                         </cell>
                         <cell>
                             Less than or equal to operator
@@ -109,7 +109,7 @@ main()
                             greater than or equal
                         </cell>
                         <cell>
-                            <math>&gt;=</math>
+                            <m>&gt;=</m>
                         </cell>
                         <cell>
                             Greater than or equal to operator
@@ -120,7 +120,7 @@ main()
                             equal
                         </cell>
                         <cell>
-                            <math>==</math>
+                            <m>==</m>
                         </cell>
                         <cell>
                             Equality operator
@@ -131,7 +131,7 @@ main()
                             not equal
                         </cell>
                         <cell>
-                            <math>!=</math>
+                            <m>!=</m>
                         </cell>
                         <cell>
                             Not equal operator
@@ -142,7 +142,7 @@ main()
                             logical and
                         </cell>
                         <cell>
-                            <math>&amp;&amp;</math>
+                            <m>&amp;&amp;</m>
                         </cell>
                         <cell>
                             Both operands true for result to be true
@@ -153,7 +153,7 @@ main()
                             logical or
                         </cell>
                         <cell>
-                            <math>||</math>
+                            <m>||</m>
                         </cell>
                         <cell>
                             One or the other operand is true for the result to be true
@@ -164,7 +164,7 @@ main()
                             logical not
                         </cell>
                         <cell>
-                            <math>!</math>
+                            <m>!</m>
                         </cell>
                         <cell>
                             Negates the truth value, false becomes true, true becomes false

--- a/pretext/Functions/DefiningFunctions.ptx
+++ b/pretext/Functions/DefiningFunctions.ptx
@@ -74,12 +74,12 @@ int main() {
             technique called <q>Newton's Method.</q> Newton's Method for approximating
             square roots performs an iterative computation that converges on the
             correct value. The equation
-            <math>newguess = \frac {1}{2} * (oldguess + \frac {n}{oldguess})</math>
-            takes a value <math>n</math> and repeatedly guesses the square root by
-            making each <math>newguess</math> the <math>oldguess</math> in the subsequent
-            iteration. The initial guess used here is <math>\frac {n}{2}</math>.
+            <m>newguess = \frac {1}{2} * (oldguess + \frac {n}{oldguess})</m>
+            takes a value <m>n</m> and repeatedly guesses the square root by
+            making each <m>newguess</m> the <m>oldguess</m> in the subsequent
+            iteration. The initial guess used here is <m>\frac {n}{2}</m>.
             <xref ref="lst-root"/> shows a function definition that accepts a value
-            <math>n</math> and returns the square root of <math>n</math> after making 20
+            <m>n</m> and returns the square root of <m>n</m> after making 20
             guesses. Again, the details of Newton's Method are hidden inside the
             function definition and the user does not have to know anything about
             the implementation to use the function for its intended purpose.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
Through the new version of the book, all the math problems were not showing because they were in the `<math>` tag instead of `<m>`. To solve this problem, I replace the `<math>` tag by  `<m>`.
## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in a case first -->
<!--- Please link to the issue here: -->
fix #139
## How Has This Been Tested?
1. Make changes locally.
2. Verify the changes locally.
![image](https://github.com/pearcej/cpp4python/assets/117699634/44d75115-e6f0-4407-8350-e7b4ef825dbc)

<!--- Please describe in detail how you tested your changes. -->
