### PR TITLE
Fix Cross-reference errors across chapter 4 (cpp4python-v2)

### DIFF
--- a/pretext/Functions/DefiningFunctions.ptx
+++ b/pretext/Functions/DefiningFunctions.ptx
@@ -78,15 +78,15 @@ int main() {
             takes a value <math>n</math> and repeatedly guesses the square root by
             making each <math>newguess</math> the <math>oldguess</math> in the subsequent
             iteration. The initial guess used here is <math>\frac {n}{2}</math>.
-            <xref ref="lst-root"/> shows a function definition that accepts a value
+            <xref ref="functions_lst-root">Listing 1</xref> shows a function definition that accepts a value
             <math>n</math> and returns the square root of <math>n</math> after making 20
             guesses. Again, the details of Newton's Method are hidden inside the
             function definition and the user does not have to know anything about
             the implementation to use the function for its intended purpose.
-            <xref ref="lst-root"/> also shows the use of the // characters as a comment
+            <xref ref="functions_lst-root">Listing 1</xref> also shows the use of the // characters as a comment
             marker. Any characters that follow the // on a line are ignored.</p>
         
-        <p xml:id="functions_lst-root" names="lst_root"><term>Listing 1</term></p>
+        <p xml:id="functions_lst-root" names="lst_root"><term>Listing 1</term>
 
     <program xml:id="newtonsmethod" interactive="activecode" language="cpp">
         <input>
@@ -113,6 +113,7 @@ int main() {
 }
         </input>
     </program>
+</p>
 
     <program xml:id="dogwalk" interactive="activecode" language="cpp">
         <input>
@@ -133,6 +134,8 @@ int main() {
 }
         </input>
     </program>
+
+
     <reading-questions xml:id="rqs-defining-functions">
         <title>Reading Question</title>
     <exercise label="dog_walker">

--- a/pretext/Functions/ParameterPassingByValue.ptx
+++ b/pretext/Functions/ParameterPassingByValue.ptx
@@ -84,9 +84,9 @@ int main( ) {
         </input>
     </program>
         </blockquote>
-        <p>For this program <xref ref="lst-swap-inputs"/> to reverse the order of the integers the users types in, the function <c>swap_values(...)</c> must be able to change the values of the arguments. Try removing one or both of the <q>&amp;</q> &#8216;s in this code to see what happens.</p>
+        <p>For this program <xref ref="lst-swap-inputs">Swap Inputs</xref> to reverse the order of the integers the users types in, the function <c>swap_values(...)</c> must be able to change the values of the arguments. Try removing one or both of the <q>&amp;</q> &#8216;s in this code to see what happens.</p>
         <p>Analyze the program and answer the question that involves parameter passing below:</p>
-
+        <p xml:id="lst-swap-inputs">
     <program xml:id="questionexample1" interactive="activecode" language="cpp">
         <input>
 // demonstrates the difference between pass-by-value
@@ -123,6 +123,7 @@ int main(){
 }
         </input>
     </program>
+</p>
 <reading-questions xml:id="rqs-parameter-passing-by-value">
     <title>Reading Questions</title>
     


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
I fixed cross-reference errors across chapter 4 as in the issue described there were some cross-reference issues many caused because of trying to refer to active codes and listings now there are no cross-reference errors across chapter 4.
## Related Issue
fix #137 
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
1. Make changes locally.
2. Verify the changes.
![image](https://github.com/pearcej/cpp4python/assets/117699634/fdc3cccc-3aea-4409-891d-5bd9d5aae051)

<!--- Please describe in detail how you tested your changes. -->
