### PR TITLE
Fix Cross-reference errors across chapter 5 (cpp4python-v2)

### DIFF
--- a/pretext/CollectionData/HashTables.ptx
+++ b/pretext/CollectionData/HashTables.ptx
@@ -127,7 +127,7 @@ main()
         <p>Hash Tables have both methods and operators. <xref ref="collection-data_collection-data_tab-hashopers"/>
             describes them, and the session shows them in action.</p>
         
-        <table xml:id="collection-data_id1"><tabular>
+        <table xml:id="collection-data_collection-data_tab-hashopers"><tabular>
             <title><term>Table 7: Important Hash Table Operators Provided in C++</term></title>
             
                 

--- a/pretext/CollectionData/Strings.ptx
+++ b/pretext/CollectionData/Strings.ptx
@@ -17,7 +17,7 @@ char cstring[] = {"Hello World!"};    // C-string or char array uses double quot
             In addition, the string library offers a huge number of
             methods, some of the most useful of which are shown in <xref ref="collection-data_collection-data_tab-stringmethods"/>.</p>
         
-        <table xml:id="collection-data_id1"><tabular>
+        <table xml:id="collection-data_collection-data_tab-stringmethods"><tabular>
             <title><term>Table 4: String Methods Provided in C++</term></title>
             
                 

--- a/pretext/CollectionData/UnorderedSet.ptx
+++ b/pretext/CollectionData/UnorderedSet.ptx
@@ -16,7 +16,7 @@
             have worked with sets in a mathematics setting. <xref ref="collection-data_collection-data_tab-setmethods"/>
             provides a summary. Examples of their use follow.</p>
         
-        <table xml:id="collection-data_id1"><tabular>
+        <table xml:id="collection-data_collection-data_tab-setmethods"><tabular>
             <title><term>Table 6: Methods Provided by Sets in C++</term></title>
             
                 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
I fixed cross-reference errors across chapter 5 as in the issue described there were some cross-reference issues many caused because of trying to refer to tables now there is no cross-reference error across chapter 5.
## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
fix #138 
## How Has This Been Tested?
1. Make changes locally.
2. Verify the changes.

<!--- Please describe in detail how you tested your changes. -->
