### PR TITLE
Add missing matching exercise in chapter seven glossary (cpp4python-v2) 

### DIFF
--- a/pretext/Exception_Handling/glossary.ptx
+++ b/pretext/Exception_Handling/glossary.ptx
@@ -28,5 +28,14 @@
                 </gi>
             
         </glossary>
+        <reading-questions xml:id="rqs-gllosary7">
+            <title>Reading Question</title>
+            
+            <exercise label="matching_ch7">
+                <statement><p>Match the words with their corresponding definition.</p></statement>
+                <feedback><p>Feedback shows incorrect matches.</p></feedback>
+            <matches><match order="1"><premise>exception</premise><response>Response to an unusual circumstance while a program is running.</response></match><match order="2"><premise>logic error</premise><response> Error in which the program/code functions, but performs incorrectly.</response></match><match order="3"><premise>runtime</premise><response>Error that occurs when a program starts.</response></match><match order="4"><premise>syntax</premise><response>Error  in the structure of a statement or expression of code.</response></match></matches></exercise> 
+            
+        </reading-questions>
     </section>
     


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
There was a missing matching exercise in the chapter 7 glossary section I added the missing exercise into the glossary section.
## Related Issue
fix #150 
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
1. Make changes locally.
2. Verify the changes.
![image](https://github.com/pearcej/cpp4python/assets/117699634/9aa8b1ee-11c7-4ef7-adff-f9acdd8358ac)

<!--- Please describe in detail how you tested your changes. -->
