### PR TITLE
Add missing matching exercise in chapter six glossary (cpp4python-v2)

### DIFF
--- a/pretext/Input_and_Output/glossary.ptx
+++ b/pretext/Input_and_Output/glossary.ptx
@@ -28,5 +28,16 @@
                 </gi>
             
         </glossary>
+        <reading-questions xml:id="rqs-glossary6">
+            <title>Reading Question</title>
+            <exercise label="matching_ch6-1">
+                <statement><p>Match the words to thier corresponding definition.</p></statement>
+                <feedback><p>Feedback shows incorrect matches.</p></feedback>
+            <matches>
+                <match order="1"><premise>stream</premise><response>An abstraction that allows you to send or receive an unknown number of bytes in input or output.</response></match>
+                <match order="2"><premise>member function</premise><response>A function that's associated with a certain type of object.</response></match><match order="3"><premise>c-string</premise><response>An array of characters that ends with a terminating null character.</response></match><match order="4"><premise>End-Of-File</premise><response>A flag that lets programs know when to stop.</response></match>
+            </matches>
+            </exercise>
+        </reading-questions>
     </section>
     


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
There was a missing matching exercise in the chapter 7 glossary section I added the missing exercise into the glossary section.
## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
fix #149 
## How Has This Been Tested?
1. Make changes locally.
2. Verify the changes.
![image](https://github.com/pearcej/cpp4python/assets/117699634/14e50be9-4cf0-4734-a358-dc8ccbf0bdaf)

<!--- Please describe in detail how you tested your changes. -->
