### PR TITLE
Move reading questions in the glossary to the summary page- chapter 2 (cpp4python-v2)

### DIFF
--- a/pretext/AtomicData/Summary.ptx
+++ b/pretext/AtomicData/Summary.ptx
@@ -1,5 +1,5 @@
 <section xml:id="atomicdata_atomicdata_atomic-data_summary">
-        <title>Summary</title>
+        <title>Summary &amp; Reading Questions</title>
         <p><ol label="1">
             <li>
                 <p>All variables must be declared before use in C++.</p>
@@ -136,6 +136,10 @@
                 </choice>
     </choices>            
     </exercise>
+    <exercise label="matching_ch2">     
+        <statement><p> Drag each glossary term to its' corresponding definition. (Note: none of the data types are in this matching, but they are in the glossary)</p></statement>
+        <feedback><p>Feedback shows incorrect matches.</p></feedback>
+    <matches><match order="1"><premise>address-of</premise><response>(&amp;) is used to access the memory address of a C++ variable.</response></match><match order="2"><premise>atomic data type</premise><response> Data type that cannot be broken down into any simpler data elements.</response></match><match order="3"><premise>dereference</premise><response>Reads data in a pointers memory location.</response></match><match order="4"><premise>pointer</premise><response>Variables that store and manipulate memory addresses.</response></match></matches></exercise>   
         </reading-questions>
     </section>
     

--- a/pretext/AtomicData/glossary.ptx
+++ b/pretext/AtomicData/glossary.ptx
@@ -52,12 +52,5 @@
                 </gi>
             
         </glossary>
-        <reading-questions xml:id="rqs-glossary2">
-            <title>Reading Question</title>
-            <exercise label="matching_ch2">
-                <statement><p> Drag each glossary term to its' corresponding definition. (Note: none of the data types are in this matching, but they are in the glossary)</p></statement>
-                <feedback><p>Feedback shows incorrect matches.</p></feedback>
-            <matches><match order="1"><premise>address-of</premise><response>(&amp;) is used to access the memory address of a C++ variable.</response></match><match order="2"><premise>atomic data type</premise><response> Data type that cannot be broken down into any simpler data elements.</response></match><match order="3"><premise>dereference</premise><response>Reads data in a pointers memory location.</response></match><match order="4"><premise>pointer</premise><response>Variables that store and manipulate memory addresses.</response></match></matches></exercise>   
-        </reading-questions>
     </section>
     


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
I moved the reading question that was on the glossary page and put it on the summary page.
## Related Issue
fix #172 
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
1. Make changes locally.
2. Verify the changes.
![image](https://github.com/pearcej/cpp4python/assets/117699634/7b370da6-137a-42e2-999c-8f89b7bbf796)

<!--- Please describe in detail how you tested your changes. -->
