### PR TITLE
Move reading questions in the glossary to the summary page- chapter 6 (cpp4python-v2)

### DIFF
--- a/pretext/Input_and_Output/Summary.ptx
+++ b/pretext/Input_and_Output/Summary.ptx
@@ -91,6 +91,14 @@ main(){
   cout &lt;&lt; inputn;
   in_stream &gt;&gt; inputn;
 }</pre><condition number="[101, 101]"><feedback><p>That is the correct answer! Good job!</p></feedback></condition><condition number="[25, 25]"><feedback><p>No. Hint: <c>inputn</c> is changed twice.</p></feedback></condition><condition number="[2515, 2515]"><feedback><p>No. Hint: <c>inputn</c> is changed twice.</p></feedback></condition><condition number="[15, 15]"><feedback><p>No. Hint: note that there is no space between the first 25 and 15!</p></feedback></condition></var></setup></exercise> 
+<exercise label="matching_ch6-1">
+    <statement><p>Match the words to thier corresponding definition.</p></statement>
+    <feedback><p>Feedback shows incorrect matches.</p></feedback>
+<matches>
+    <match order="1"><premise>stream</premise><response>An abstraction that allows you to send or receive an unknown number of bytes in input or output.</response></match>
+    <match order="2"><premise>member function</premise><response>A function that's associated with a certain type of object.</response></match><match order="3"><premise>c-string</premise><response>An array of characters that ends with a terminating null character.</response></match><match order="4"><premise>End-Of-File</premise><response>A flag that lets programs know when to stop.</response></match>
+</matches>
+</exercise>
 </reading-questions>
     </section>
 

--- a/pretext/Input_and_Output/glossary.ptx
+++ b/pretext/Input_and_Output/glossary.ptx
@@ -28,16 +28,5 @@
                 </gi>
             
         </glossary>
-        <reading-questions xml:id="rqs-glossary6">
-            <title>Reading Question</title>
-            <exercise label="matching_ch6-1">
-                <statement><p>Match the words to thier corresponding definition.</p></statement>
-                <feedback><p>Feedback shows incorrect matches.</p></feedback>
-            <matches>
-                <match order="1"><premise>stream</premise><response>An abstraction that allows you to send or receive an unknown number of bytes in input or output.</response></match>
-                <match order="2"><premise>member function</premise><response>A function that's associated with a certain type of object.</response></match><match order="3"><premise>c-string</premise><response>An array of characters that ends with a terminating null character.</response></match><match order="4"><premise>End-Of-File</premise><response>A flag that lets programs know when to stop.</response></match>
-            </matches>
-            </exercise>
-        </reading-questions>
     </section>
     


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
I moved the reading question that was on the glossary page and put it on the summary page.
## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
fix #175  
## How Has This Been Tested?
1. Make changes locally.
2. Verify the changes.
![image](https://github.com/pearcej/cpp4python/assets/117699634/d2517429-4a53-47d1-949c-c24010178be2)


<!--- Please describe in detail how you tested your changes. -->
