### PR TITLE
Move reading questions in the glossary to the summary page- chapter 7 (cpp4python-v2)

### DIFF
--- a/pretext/Exception_Handling/Summary.ptx
+++ b/pretext/Exception_Handling/Summary.ptx
@@ -1,5 +1,5 @@
 <section xml:id="exception_handling_exception_handling_exception_-handling_summary">
-        <title>Summary</title>
+        <title>Summary &amp; Reading Questions</title>
         <p><ol label="1">
             <li>
                 <p>There are two types of errors that occur while writing programs: syntax errors and logic errors</p>
@@ -43,7 +43,13 @@
 <cline><area>else {</area>:</cline>
 <cline><area>cout &lt;&lt; You cannot vote in the U.S yet.;</area>:</cline>
 <cline>}</cline>
-</areas></exercise>  </reading-questions>
+</areas></exercise>  
+
+<exercise label="matching_ch7">
+    <statement><p>Match the words with their corresponding definition.</p></statement>
+    <feedback><p>Feedback shows incorrect matches.</p></feedback>
+<matches><match order="1"><premise>exception</premise><response>Response to an unusual circumstance while a program is running.</response></match><match order="2"><premise>logic error</premise><response> Error in which the program/code functions, but performs incorrectly.</response></match><match order="3"><premise>runtime</premise><response>Error that occurs when a program starts.</response></match><match order="4"><premise>syntax</premise><response>Error  in the structure of a statement or expression of code.</response></match></matches></exercise> 
+</reading-questions>
       
     </section>
 

--- a/pretext/Exception_Handling/glossary.ptx
+++ b/pretext/Exception_Handling/glossary.ptx
@@ -28,14 +28,5 @@
                 </gi>
             
         </glossary>
-        <reading-questions xml:id="rqs-gllosary7">
-            <title>Reading Question</title>
-            
-            <exercise label="matching_ch7">
-                <statement><p>Match the words with their corresponding definition.</p></statement>
-                <feedback><p>Feedback shows incorrect matches.</p></feedback>
-            <matches><match order="1"><premise>exception</premise><response>Response to an unusual circumstance while a program is running.</response></match><match order="2"><premise>logic error</premise><response> Error in which the program/code functions, but performs incorrectly.</response></match><match order="3"><premise>runtime</premise><response>Error that occurs when a program starts.</response></match><match order="4"><premise>syntax</premise><response>Error  in the structure of a statement or expression of code.</response></match></matches></exercise> 
-            
-        </reading-questions>
     </section>
     


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
I moved the reading question that was on the glossary page and put it on the summary page.
## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
fix #176 
## How Has This Been Tested?
1. Make changes locally.
2. Verify the changes.
![image](https://github.com/pearcej/cpp4python/assets/117699634/b409866d-2dd2-407c-8e31-d6a1048e090b)


<!--- Please describe in detail how you tested your changes. -->
