### PR TITLE
Fix a typo in 6.3

### DIFF
--- a/_sources/Input_and_Output/InputandOutput.rst
+++ b/_sources/Input_and_Output/InputandOutput.rst
@@ -66,7 +66,7 @@ Pictorally, we get a stream of data flowing out of the program:
 
 Because out_stream is an object of type ``<ofstream>``, connecting it to the file named "anotherFile.txt" will create that file if it does not exist. If the file "anotherFile.txt" already exists, it will be wiped and replaced with whatever is fed into the output stream.
 
-To disconnect the ``ifstream`` in_stream from whatever file it opened, we use it's ``close()`` member function:
+To disconnect the ``ifstream`` in_stream from whatever file it opened, we use its ``close()`` member function:
 
 ::
 

--- a/pretext/Input_and_Output/FileOperations.ptx
+++ b/pretext/Input_and_Output/FileOperations.ptx
@@ -11,7 +11,7 @@
         
         <figure align="center" xml:id="fig-read-write"><image source="Input_and_Output/Write_Open.jpg" width="50%" alt="image"/></figure>
         <p>Because out_stream is an object of type <c>&lt;ofstream&gt;</c>, connecting it to the file named <q>anotherFile.txt</q> will create that file if it does not exist. If the file <q>anotherFile.txt</q> already exists, it will be wiped and replaced with whatever is fed into the output stream.</p>
-        <p>To disconnect the <c>ifstream</c> in_stream from whatever file it opened, we use it's <c>close()</c> member function:</p>
+        <p>To disconnect the <c>ifstream</c> in_stream from whatever file it opened, we use its <c>close()</c> member function:</p>
         <pre>in_stream.close();</pre>
         <p>To close the file for <c>out_stream</c>, we use its <c>close()</c> function, which also adds an end-of-file marker to indicate where the end of the file is:</p>
         <pre>out_stream.close();</pre>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
I fixed a typo in 6.3 as in the issue described there was a grammatical problem now it is fixed.
<!--- Describe your changes in detail -->

## Related Issue
fix https://github.com/RunestoneInteractive/cpp4python/issues/16
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
## Pretext version
1. Make changes locally.
2. Verify the changes.

<!--- Please describe in detail how you tested your changes. -->
