### PR TITLE
Fix a typo in 5.4

### DIFF
--- a/pretext/CollectionData/Strings.ptx
+++ b/pretext/CollectionData/Strings.ptx
@@ -251,7 +251,7 @@ main()
 
     </exercise>
     <exercise label="matching_strings">
-        <statement><p> Match the String operations with their corresponding explination.</p></statement>
+        <statement><p> Match the String operations with their corresponding explanation.</p></statement>
         <feedback><p>Feedback shows incorrect matches.</p></feedback>
     <matches><match order="1"><premise>[ ]</premise><response>Accesses value of an element.</response></match><match order="2"><premise>find</premise><response> Returns the index of the first occurrence of item.</response></match><match order="3"><premise>=</premise><response> Assigns value to an element.</response></match><match order="4"><premise>push_back</premise><response>Adjoins a character to the end of the string.</response></match><match order="5"><premise>pop_back</premise><response>Removes the last character from the end of the string.</response></match></matches></exercise>
     <exercise label="matching_strings1">

--- a/pretext/CollectionData/Strings.ptx
+++ b/pretext/CollectionData/Strings.ptx
@@ -251,7 +251,7 @@ main()
 
     </exercise>
     <exercise label="matching_strings">
-        <statement><p> Match the String operation with their corresponding explanation.</p></statement>
+        <statement><p> Match the String operations with their corresponding explination.</p></statement>
         <feedback><p>Feedback shows incorrect matches.</p></feedback>
     <matches><match order="1"><premise>[ ]</premise><response>Accesses value of an element.</response></match><match order="2"><premise>find</premise><response> Returns the index of the first occurrence of item.</response></match><match order="3"><premise>=</premise><response> Assigns value to an element.</response></match><match order="4"><premise>push_back</premise><response>Adjoins a character to the end of the string.</response></match><match order="5"><premise>pop_back</premise><response>Removes the last character from the end of the string.</response></match></matches></exercise>
     <exercise label="matching_strings1">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
I fixed a grammatical error in 5.4 I changed the word "operation" to "operations".
## Related Issue
fix https://github.com/RunestoneInteractive/cpp4python/issues/6
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
1. Make the changes locally.
2. Test the changes.
<!--- Please describe in detail how you tested your changes. -->
