### PR TITLE
Fixing issue 199

### DIFF
--- a/pretext/AtomicData/Pointers.ptx
+++ b/pretext/AtomicData/Pointers.ptx
@@ -193,7 +193,7 @@ int main( ) {
             <figure align="center" xml:id="id4"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Dangling pointer reference</caption><image source="AtomicData/new_point_broken.png" width="50%" alt="image"/></figure>
             <p>If your compiler does not catch that error (the one for this class may),
                 the first <c>cout</c> instruction outputs</p>
-            <pre>varN value: 50</pre>
+            <pre>varN value: 100</pre>
             <p>which is expected because you changed where ptrN is pointing to and
                 NOT the contents of where it is pointing.</p>
             <p>The second <c>cout</c> instruction is a disaster because

--- a/pretext/AtomicData/Pointers.ptx
+++ b/pretext/AtomicData/Pointers.ptx
@@ -193,7 +193,7 @@ int main( ) {
             <figure align="center" xml:id="id4"><caption xmlns:c="https://www.sphinx-doc.org/" xmlns:changeset="https://www.sphinx-doc.org/" xmlns:citation="https://www.sphinx-doc.org/" xmlns:cpp="https://www.sphinx-doc.org/" xmlns:index="https://www.sphinx-doc.org/" xmlns:js="https://www.sphinx-doc.org/" xmlns:math="https://www.sphinx-doc.org/" xmlns:py="https://www.sphinx-doc.org/" xmlns:rst="https://www.sphinx-doc.org/" xmlns:std="https://www.sphinx-doc.org/">Dangling pointer reference</caption><image source="AtomicData/new_point_broken.png" width="50%" alt="image"/></figure>
             <p>If your compiler does not catch that error (the one for this class may),
                 the first <c>cout</c> instruction outputs</p>
-            <pre>After changing *ptrN, varN now has: 50</pre>
+            <pre>varN value: 50</pre>
             <p>which is expected because you changed where ptrN is pointing to and
                 NOT the contents of where it is pointing.</p>
             <p>The second <c>cout</c> instruction is a disaster because


### PR DESCRIPTION
Changed the text in chapter 2.5.2 to accurately reflect the output
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
Changed the text from "After changing *ptrN, varN now has: 50 " to "varN value: 100" to accurately reflect the output of the code.

## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
Issue #199 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Loaded the changes in my localhost book to test multiple times.