### PR TITLE
Fixed spelling

### DIFF
--- a/pretext/Functions/DefiningFunctions.ptx
+++ b/pretext/Functions/DefiningFunctions.ptx
@@ -117,7 +117,7 @@ int main() {
 
     <program xml:id="dogwalk" interactive="activecode" language="cpp">
         <input>
-// function that retuns outputs number of steps wallked
+// function that returns outputs number of steps walked
 #include &lt;iostream&gt;
 using namespace std;
 

--- a/pretext/Functions/DefiningFunctions.ptx
+++ b/pretext/Functions/DefiningFunctions.ptx
@@ -117,7 +117,7 @@ int main() {
 
     <program xml:id="dogwalk" interactive="activecode" language="cpp">
         <input>
-// function that returns outputs number of steps walked
+// function that returns the output number of steps walked
 #include &lt;iostream&gt;
 using namespace std;
 


### PR DESCRIPTION
# Description
Changed an error in the second part of Listing 1 from "retuns outpouts of steps wallked" to "returns the output of steps walked" 

<img width="1710" height="1107" alt="Screenshot 2026-07-21 at 1 09 40 PM" src="https://github.com/user-attachments/assets/0b421729-b576-4969-bb6c-21a07f015d77" />

## Related Issue
Fixes #265 

## How Has This Been Tested?
Tested on local build 
Reviewed by puskar
