### PR TITLE
Fix principle typo in Chapter 8 introduction

### DIFF
--- a/pretext/Turtles/introduction.ptx
+++ b/pretext/Turtles/introduction.ptx
@@ -1,6 +1,6 @@
 <section xml:id="turtles_turtles_turtles_introduction">
         <title>Introduction</title>
-        <p>C++ is designed with the principal that speed is more important than safety and error-checking.
+        <p>C++ is designed with the principle that speed is more important than safety and error-checking.
             This differs from languages like Python, which is considerably more restrictive in regards to
             aspects such as memory allocations and resource management. C++ is translated to <q>machine language</q>
             when it is compiled, which is a step skipped by Python. Python skips this step in favor of immediate


### PR DESCRIPTION
# Description
Corrects the word “principal” to “principle” in the Chapter 8 introduction.

## Related Issue
Fixes issue #293 

## How Has This Been Tested?
Tested on Local Build 
Reviewed by @harrisonj2-v

***BEFORE****
<img width="756" height="897" alt="BEFORE" src="https://github.com/user-attachments/assets/70a7a828-861e-4c74-a757-f169b78f699e" />

***AFTER***
<img width="1093" height="912" alt="AFTER" src="https://github.com/user-attachments/assets/2814f6b5-4b8a-4ec4-a29d-9674b1a9dd80" />

