### PR TITLE
Correct emphasis and term markup in Chapter 4

### DIFF
--- a/pretext/Functions/ArraysAsParameter.ptx
+++ b/pretext/Functions/ArraysAsParameter.ptx
@@ -21,7 +21,7 @@
     };
     return (total / length);
 }</pre>
-        <p>Array parameters look like <em>pass by value</em>, but they are effectively similar to <em>pass by reference</em> parameters. When they execute, the functions with these parameters do not make private copies of the arrays. Instead, the reference is passed to reduce the impact on memory. Arrays can therefore always be permanently changed when passed as arguments to functions.</p>
+        <p>Array parameters look like <term>pass by value</term>, but they are effectively similar to <term>pass by reference</term> parameters. When they execute, the functions with these parameters do not make private copies of the arrays. Instead, the reference is passed to reduce the impact on memory. Arrays can therefore always be permanently changed when passed as arguments to functions.</p>
         <p>After a call to the following function, each element in the third array argument is equal to the sum of the corresponding two elements in the first and second arguments:</p>
         <pre>void add_lists( int first[], int second[], int total[], int length ) {
     //return type void which indicates that nothing is returned

--- a/pretext/Functions/ParameterPassingByValue.ptx
+++ b/pretext/Functions/ParameterPassingByValue.ptx
@@ -30,7 +30,7 @@ void callingFunction() { /*return type void which indicates
             so the <c>cout</c> statement within this function produces the output:</p>
         <pre>nextVar = 20 inputVar = 4</pre>
         <p>Notice what happens when <c>functionExample(...)</c> ends and execution returns to <c>callingFunction()</c>.
-            The contents of <em>myVar</em> is <term>still the same</term>, as the location for <em>myVar</em> differs from where <em>inputVar</em>
+            The contents of <em>myVar</em> is <em>still the same</em>, as the location for <em>myVar</em> differs from where <em>inputVar</em>
             is stored. Thus, <em>myVar</em> still has the value 10, and the <c>cout</c> statement after the function call will
             produce the output:</p>
         <pre>myVar = 10</pre>


### PR DESCRIPTION
# Description
- Changed “pass by value” and “pass by reference” from <em> to <term> because they are technical concepts.

## Related Issue
-Partially fixes #295 

## How Has This Been Tested?
- Tested in local build 
- Reviewed by @harrisonj2-v

***AFTER***

<img width="797" height="262" alt="chapter 5" src="https://github.com/user-attachments/assets/868a2790-d913-4be5-bc14-842159ee2828" />

