### PR TITLE
Correct emphasis and term markup in Chapter 5

### DIFF
--- a/pretext/CollectionData/Arrays.ptx
+++ b/pretext/CollectionData/Arrays.ptx
@@ -1,6 +1,6 @@
 <section xml:id="collection-data_arrays">
         <title>Arrays</title>
-        <p><term>What is an Array?</term>
+        <p><em>What is an Array?</em>
             An array is a data structure consisting of an ordered collection of data elements,
             of identical type in which each element can be identified by an array index.
             More technically, an array data structure is an ordered arrangement of values
@@ -9,10 +9,10 @@
         <blockquote>
             <p><ol label="1">
                 <li>
-                    <p><em>statically allocated</em> in which the array size is fixed at compile-time and cannot change</p>
+                    <p><term>statically allocated</term> in which the array size is fixed at compile-time and cannot change</p>
                 </li>
                 <li>
-                    <p><em>dynamically allocated</em> <idx>dynamically allocated</idx>in which pointers are used in the allocation process so the size can change at run-time</p>
+                    <p><term>dynamically allocated</term> <idx>dynamically allocated</idx>in which pointers are used in the allocation process so the size can change at run-time</p>
                 </li>
             </ol></p>
         </blockquote>
@@ -29,7 +29,7 @@
             of memory locations that we can then manipulate as a single
             entity, and that at the same time gives us direct access to each
             individual component.</p>
-        <p><term>Why use an Array?</term></p>
+        <p><em>Why use an Array?</em></p>
         <p>C++ is a language often used for real-time or low-level processing
             where speed is essential and/or there is only a fixed amount of space
             available.</p>
@@ -52,7 +52,7 @@ string arr3[] = {"this", "is", "an", "array"}; // This is size 4.</pre>
             so the following are not the same.</p>
         <pre>double darray[] = {1.2};  // must use index to access value
 double ddouble = 1.2;     // cannot use index to access value</pre>
-        <p><term>Be Cautious with Arrays</term></p>
+        <p><em>Be Cautious with Arrays</em></p>
         <p>The speed and low-level control that arrays offer us
             as programmers is powerful&#8230; and dangerous.
             As a Python programmer, using a C++ array will
@@ -145,7 +145,7 @@ main()
         <p>You should use an array when you have a need for speed
             or you need to work with hardware constraints.
             Otherwise, you may want to consider using another collection data type,
-            the <em>vector</em>.</p>
+            the <term>vector</term>.</p>
         <TabNode tabname="C++" tabnode_options="{'subchapter': 'Arrays', 'chapter': 'CollectionData', 'basecourse': 'cpp4python', 'optional': '', 'optclass': '', 'tabname': 'C++'}">
 
     <program xml:id="array_werror_cpp" interactive="activecode" language="cpp">

--- a/pretext/CollectionData/HashTables.ptx
+++ b/pretext/CollectionData/HashTables.ptx
@@ -2,17 +2,17 @@
         <title>Hash Tables</title>
         <p>If you have used a Python dictionary, then you have used a <em>hash table</em>.
             A <term>hash table</term> <idx>hash table</idx> is a collection of associated pairs of
-            items where each pair consists of a <em>key</em> and a <em>value</em>.
-            Hash tables are often called the more general term <em>map</em>
+            items where each pair consists of a <term>key</term> and a <term>value</term>.
+            Hash tables are often called the more general term <term>map</term>
             because the associated hash function <q>maps</q> the key to the value.
-            Nevertheless, it is better to use the more precise term, <em>hash table</em>
+            Nevertheless, it is better to use the more precise term, <term>hash table</term>
             because other kinds of maps are sometimes implemented with a different underlying data structure.</p>
-        <p>Each hash table has a <em>hash function</em> <idx>hash function</idx> which
+        <p>Each hash table has a <term>hash function</term> <idx>hash function</idx> which
             given the key as input to the hash function
             returns the location of the associated value as the output.
             This makes look up fast.</p>
         <p>In Python, the dictionary data type represents the implementation of the hash table.
-            In C++, the <em>unordered_map</em> <idx>unordered_map</idx> implements the hash table, and the <c>&lt;unordered_map&gt;</c>
+            In C++, the <term>unordered_map</term> <idx>unordered_map</idx> implements the hash table, and the <c>&lt;unordered_map&gt;</c>
             library must be included as follows:</p>
         <pre>#include &lt;unordered_map&gt;</pre>
         <p>The syntax for hash table access is much like we might expect
@@ -25,8 +25,8 @@
 
     <program xml:id="hashtable1_cpp" interactive="activecode" language="cpp">
         <input>
-// Creates a hash table that maches
-// the english letter to it's spanish
+// Creates a hash table that matches
+// the English letter to its Spanish
 // equivalent, and outputs the size of
 // the table to the console
 #include &lt;iostream&gt;
@@ -82,8 +82,8 @@ main()
 
     <program xml:id="hashtable2_cpp" interactive="activecode" language="cpp">
         <input>
-// Creates a hash table that maches
-// the english letter to it's spanish
+// Creates a hash table that matches
+// the English letter to its Spanish
 // equivalent, and outputs every item
 // in the table to the console
 #include &lt;iostream&gt;

--- a/pretext/CollectionData/Strings.ptx
+++ b/pretext/CollectionData/Strings.ptx
@@ -1,9 +1,9 @@
 <section xml:id="collection-data_strings">
         <title>Strings</title>
         <p><term>Strings</term> <idx>strings</idx>are sequential collections of zero or more characters such as letters, numbers
-            and other symbols. There are actually two types of strings in C++ . The <em>C++ string</em> or just <em>string</em> from the
+            and other symbols. There are actually two types of strings in C++ . The <term>C++ string</term> or just <term>string</term> from the
             <c>&lt;string&gt;</c> library is the more modern type, and it is very similar to the Python string class.
-            The old style <em>C-string</em> which is essentially
+            The old style <term>C-string</term> which is essentially
             an array of <c>char</c> type. The char type itself is actually distinct from both types of strings.</p>
         <pre>char cppchar = 'a';   // char values use single quotes
 string cppstring = "Hello World!";  // C++ strings use double quotes

--- a/pretext/CollectionData/UnorderedSet.ptx
+++ b/pretext/CollectionData/UnorderedSet.ptx
@@ -3,15 +3,15 @@
         <p>An <term>unordered_set</term> <idx>unordered_set</idx> is an unordered collection of zero or more unique C++ data values
             of a particular type.
             To use unordered_sets, you import <c>unordered_set</c> from the Standard template library with
-            <c>#include &lt;unorderd_set&gt;</c>.</p>
+            <c>#include &lt;unordered_set&gt;</c>.</p>
         <p>Unordered_sets allow for fast retrieval of individual elements based on their value.
             In an unordered_set, the value of an element is at the same time its key, that identifies it uniquely.
-            <c>Keys</c> are <term>immutable</term>, therefore, the elements in an <c>unordered_set</c> cannot be modified once in the container -
+            </c>Keys</c> are <term>immutable</term>, therefore, the elements in an <c>unordered_set</c> cannot be modified once in the container -
             However, they can be inserted and removed.</p>
         <p>Unordered sets do not allow duplicates and are initialized using comma-delimited
             values enclosed in curly braces. The collection can be assigned to
             a variable as shown below.</p>
-        <pre>set&lt;int&gt; mySet = {3, 6, 4, 78, 10}</pre>
+        <pre>unordered_set&lt;int&gt; mySet = {3, 6, 4, 78, 10};</pre>
         <p>Unordered sets support a number of methods that should be familiar to those who
             have worked with sets in a mathematics setting. <xref ref="collection-data_collection-data_tab-setmethods"/>
             provides a summary. Examples of their use follow.</p>
@@ -120,7 +120,7 @@
     <program xml:id="Unordered_set_example" interactive="activecode" language="cpp">
         <input>
 // Function that checks to see if a char
-// is in the unorderd set
+// is in the unordered set
 #include &lt;iostream&gt;
 #include &lt;unordered_set&gt;
 using namespace std;

--- a/pretext/CollectionData/Vectors.ptx
+++ b/pretext/CollectionData/Vectors.ptx
@@ -140,7 +140,7 @@
         <p>A very common programming task is to grow a vector using the <c>push_back()</c> method to append to the vector
             as we see in the next example.
             Because vectors can change size, vectors typically allocate some extra storage to accommodate for possible growth.
-            Thus the vector typically has an actual <em>capacity</em> greater than the storage <em>size</em> strictly needed to contain its elements.</p>
+            Thus the vector typically has an actual <term>capacity</term> greater than the storage <term>size</term> strictly needed to contain its elements.</p>
         <subsection xml:id="collection-data_iterating-through-vectors">
             <title>Iterating through Vectors</title>
             <p>When iterating vectors, you must first find the length of your container. You can simply call the <c>.length()</c> function.


### PR DESCRIPTION
# Description
- Changed technical terminology from <em> to <term> where appropriate.
- Replaced or removed <term> markup used for ordinary emphasis and structural labels.
-Updated the Arrays, Vectors, Strings, Hash Tables, and Unordered Sets sections.

## Related Issue
- Fixes Issue #295 

## How Has This Been Tested?
- Tested on local build 
- Reviewed by @harrisonj2-v 
